### PR TITLE
Fix daily data timing + add missing icon for Expected Monthly Cost

### DIFF
--- a/custom_components/globird_ha/coordinator.py
+++ b/custom_components/globird_ha/coordinator.py
@@ -30,28 +30,22 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Number of 30-minute intervals expected in a fully-published smart-meter day.
-# GloBird publishes a new day's usage entry shortly after midnight, but the
-# interval data may take several more hours to appear.  Only once all 48 slots
-# are present do we consider the day complete and allow sensor updates.
-_USAGE_COMPLETE_INTERVAL_COUNT = 48
-
 
 def _is_usage_complete(usage_summary: dict[str, Any]) -> bool:
-    """Return True if the latest day's usage data appears to be fully published.
+    """Return True if the latest day's usage data appears fully published.
 
-    For smart meters the portal returns a ``usageArray`` of 30-minute interval
-    values.  We treat the day as complete only when all 48 half-hour slots are
-    present.  If no interval data is available (basic meter) we fall back to
-    requiring a non-zero ``latest_day_usage`` value.
+    GloBird posts a new day's entry to the usage API shortly after midnight,
+    but ``latest_day_usage`` is zero (or absent) until the full day's data
+    has been processed — typically several hours later.  Requiring a positive
+    usage total ensures sensors never show a partial day's figures.
+
+    Note: the ``latest_intervals`` array is not used here because GloBird
+    returns all-zero interval arrays even for complete days, making interval
+    count an unreliable completeness signal.
     """
     if not usage_summary or usage_summary.get("latest_day") is None:
         return False
-    intervals: list[Any] = usage_summary.get("latest_intervals") or []
-    if intervals:
-        return len(intervals) == _USAGE_COMPLETE_INTERVAL_COUNT
-    # Basic meter or no interval data returned: accept any non-zero usage value.
-    return bool(usage_summary.get("latest_day_usage"))
+    return (usage_summary.get("latest_day_usage") or 0) > 0
 
 
 class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -212,14 +206,14 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 usage_summary = fresh_detail.get("usage_summary") or {}
                 if not _is_usage_complete(usage_summary) and isinstance(cached_detail, dict):
                     # Usage data for the latest day is not yet fully published
-                    # (partial or zero intervals).  Retain the previously confirmed
-                    # service data so that sensors do not update with partial values.
+                    # (latest_day_usage is zero or absent).  Retain the previously
+                    # confirmed service data so sensors do not update with partial values.
                     _LOGGER.debug(
                         "GloBird service %s: usage data incomplete "
-                        "(latest_day=%s, intervals=%d); retaining cached data.",
+                        "(latest_day=%s, latest_day_usage=%s); retaining cached data.",
                         sid,
                         usage_summary.get("latest_day"),
-                        len(usage_summary.get("latest_intervals") or []),
+                        usage_summary.get("latest_day_usage"),
                     )
                     service_data[sid] = cached_detail
                 else:

--- a/custom_components/globird_ha/coordinator.py
+++ b/custom_components/globird_ha/coordinator.py
@@ -30,6 +30,29 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Number of 30-minute intervals expected in a fully-published smart-meter day.
+# GloBird publishes a new day's usage entry shortly after midnight, but the
+# interval data may take several more hours to appear.  Only once all 48 slots
+# are present do we consider the day complete and allow sensor updates.
+_USAGE_COMPLETE_INTERVAL_COUNT = 48
+
+
+def _is_usage_complete(usage_summary: dict[str, Any]) -> bool:
+    """Return True if the latest day's usage data appears to be fully published.
+
+    For smart meters the portal returns a ``usageArray`` of 30-minute interval
+    values.  We treat the day as complete only when all 48 half-hour slots are
+    present.  If no interval data is available (basic meter) we fall back to
+    requiring a non-zero ``latest_day_usage`` value.
+    """
+    if not usage_summary or usage_summary.get("latest_day") is None:
+        return False
+    intervals: list[Any] = usage_summary.get("latest_intervals") or []
+    if intervals:
+        return len(intervals) == _USAGE_COMPLETE_INTERVAL_COUNT
+    # Basic meter or no interval data returned: accept any non-zero usage value.
+    return bool(usage_summary.get("latest_day_usage"))
+
 
 class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator for fetching GloBird portal data."""
@@ -180,12 +203,27 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             for service in services:
                 sid = service_id(service)
                 cached_detail = cached_service_data.get(sid)
-                service_data[sid] = await self._fetch_service_detail(
+                fresh_detail = await self._fetch_service_detail(
                     service,
                     data.get("read_meters"),
                     data.get("service_status"),
                     cached_detail if isinstance(cached_detail, dict) else {},
                 )
+                usage_summary = fresh_detail.get("usage_summary") or {}
+                if not _is_usage_complete(usage_summary) and isinstance(cached_detail, dict):
+                    # Usage data for the latest day is not yet fully published
+                    # (partial or zero intervals).  Retain the previously confirmed
+                    # service data so that sensors do not update with partial values.
+                    _LOGGER.debug(
+                        "GloBird service %s: usage data incomplete "
+                        "(latest_day=%s, intervals=%d); retaining cached data.",
+                        sid,
+                        usage_summary.get("latest_day"),
+                        len(usage_summary.get("latest_intervals") or []),
+                    )
+                    service_data[sid] = cached_detail
+                else:
+                    service_data[sid] = fresh_detail
 
             data["service_data"] = service_data
 

--- a/custom_components/globird_ha/coordinator.py
+++ b/custom_components/globird_ha/coordinator.py
@@ -34,18 +34,22 @@ _LOGGER = logging.getLogger(__name__)
 def _is_usage_complete(usage_summary: dict[str, Any]) -> bool:
     """Return True if the latest day's usage data appears fully published.
 
-    GloBird posts a new day's entry to the usage API shortly after midnight,
-    but ``latest_day_usage`` is zero (or absent) until the full day's data
-    has been processed — typically several hours later.  Requiring a positive
-    usage total ensures sensors never show a partial day's figures.
+    GloBird posts a new day's entry shortly after midnight with zero values;
+    the real data arrives hours later.  We require at least one of
+    ``latest_day_usage`` (grid import) or ``latest_day_export`` (solar export)
+    to be non-zero before accepting the data as complete.
 
-    Note: the ``latest_intervals`` array is not used here because GloBird
-    returns all-zero interval arrays even for complete days, making interval
-    count an unreliable completeness signal.
+    Using OR rather than AND handles legitimate edge cases:
+    - A day where battery + solar covered all consumption → import may be 0.
+    - A cloudy/rainy day with no solar generation → export may be 0.
+    Only if both are zero simultaneously is the data considered incomplete.
     """
     if not usage_summary or usage_summary.get("latest_day") is None:
         return False
-    return (usage_summary.get("latest_day_usage") or 0) > 0
+    return (
+        (usage_summary.get("latest_day_usage") or 0) > 0
+        or (usage_summary.get("latest_day_export") or 0) > 0
+    )
 
 
 class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -205,15 +209,16 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 usage_summary = fresh_detail.get("usage_summary") or {}
                 if not _is_usage_complete(usage_summary) and isinstance(cached_detail, dict):
-                    # Usage data for the latest day is not yet fully published
-                    # (latest_day_usage is zero or absent).  Retain the previously
+                    # Neither import nor export has a non-zero value for the latest
+                    # day — data is not yet fully published.  Retain the previously
                     # confirmed service data so sensors do not update with partial values.
                     _LOGGER.debug(
                         "GloBird service %s: usage data incomplete "
-                        "(latest_day=%s, latest_day_usage=%s); retaining cached data.",
+                        "(latest_day=%s, import=%s, export=%s); retaining cached data.",
                         sid,
                         usage_summary.get("latest_day"),
                         usage_summary.get("latest_day_usage"),
+                        usage_summary.get("latest_day_export"),
                     )
                     service_data[sid] = cached_detail
                 else:

--- a/custom_components/globird_ha/coordinator.py
+++ b/custom_components/globird_ha/coordinator.py
@@ -208,15 +208,38 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     cached_detail if isinstance(cached_detail, dict) else {},
                 )
                 usage_summary = fresh_detail.get("usage_summary") or {}
-                if not _is_usage_complete(usage_summary) and isinstance(cached_detail, dict):
-                    # Neither import nor export has a non-zero value for the latest
-                    # day — data is not yet fully published.  Retain the previously
-                    # confirmed service data so sensors do not update with partial values.
+                cost_summary = fresh_detail.get("cost_summary") or {}
+                cost_day = cost_summary.get("latest_day")
+                usage_day = usage_summary.get("latest_day")
+
+                # Hold back the entire service detail until both usage and cost
+                # data are fully published and aligned.  This ensures all service
+                # sensors — usage totals, cost totals, billing period, ZeroHero,
+                # weather, etc. — update together at the same time as
+                # latest_data_date rather than in separate waves.
+                #
+                # Two conditions trigger the hold-back (either is sufficient):
+                #   1. Usage incomplete: both latest_day_usage and latest_day_export
+                #      are zero/absent — GloBird has posted the new day stub but
+                #      real meter reads have not yet landed.
+                #   2. Cost ahead of usage: GloBird sometimes publishes provisional
+                #      cost for the new day before usage meter reads are finalised,
+                #      advancing cost_summary.latest_day ahead of usage_summary.
+                #      Accepting fresh data in this state would update cost sensors
+                #      with provisional figures an hour or more early.
+                cost_is_ahead = bool(cost_day and usage_day and cost_day > usage_day)
+                should_hold = not _is_usage_complete(usage_summary) or cost_is_ahead
+
+                if should_hold and isinstance(cached_detail, dict):
                     _LOGGER.debug(
-                        "GloBird service %s: usage data incomplete "
-                        "(latest_day=%s, import=%s, export=%s); retaining cached data.",
+                        "GloBird service %s: holding back update "
+                        "(usage_complete=%s, cost_ahead=%s, "
+                        "usage_day=%s, cost_day=%s, import=%s, export=%s).",
                         sid,
-                        usage_summary.get("latest_day"),
+                        _is_usage_complete(usage_summary),
+                        cost_is_ahead,
+                        usage_day,
+                        cost_day,
                         usage_summary.get("latest_day_usage"),
                         usage_summary.get("latest_day_export"),
                     )

--- a/custom_components/globird_ha/sensor.py
+++ b/custom_components/globird_ha/sensor.py
@@ -665,7 +665,7 @@ class GloBirdExpectedMonthlyCostSensor(GloBirdServiceBaseSensor):
 
     sensor_key = "expected_month_cost"
     sensor_name = "Expected Monthly Cost"
-    icon = "mdi:cash-calendar"
+    icon = "mdi:calendar-question"
     native_unit_of_measurement = CURRENCY_AUD
     device_class = SensorDeviceClass.MONETARY
     state_class = None


### PR DESCRIPTION

## Summary

Two independent changes in this PR:

1. **`coordinator.py`** — Hold back all service-level sensor updates until GloBird's daily usage and cost data are fully published
2. **`sensor.py`** — Add missing icon to the Expected Monthly Cost sensor

---

## 1. Daily data fetch timing (`coordinator.py`)

### Problem

GloBird publishes the previous day's data in multiple phases after midnight, not all at once:

- **Phase 1 (~midnight):** A provisional cost entry is posted to the cost API before the actual meter reads are finalised. This advanced `cost_summary.latest_day` to the new date while `usage_summary.latest_day` remained on the prior confirmed day.
- **Phase 2 (~1–2 hours later):** The real meter data lands and all values are finalised.

This caused service-level sensors — including `latest_daily_cost`, `recent_usage_total`, `recent_solar_export_total`, `billing_period_days`, `expected_monthly_cost`, `zerohero_status`, and others — to update in separate waves through the night with partial or provisional data, rather than all at once when the data was complete.

### Fix

Added a `_is_usage_complete()` helper and a unified hold-back condition in the service data fetch loop.

**`_is_usage_complete(usage_summary)`** returns `True` when at least one of `latest_day_usage` (grid import) or `latest_day_export` (solar export) is non-zero for the latest day. Using OR rather than AND handles legitimate edge cases:
- A day where battery + solar covered all consumption → import may be 0
- A cloudy/rainy day with no solar generation → export may be 0

Only if both are zero simultaneously is the data treated as an incomplete midnight stub.

**The hold-back condition** (either triggers a full hold):
1. **Usage incomplete** — both import and export are zero/absent for the latest day
2. **Cost ahead of usage** — `cost_summary.latest_day > usage_summary.latest_day`, meaning provisional cost has been published before the meter reads are finalised

When either condition is met and a prior confirmed cache exists, the entire `service_data` for that service is held at its cached values. No partial substitution — all service sensors update together in a single wave once both conditions clear.

Top-level sensors (`balance`, `account_summary`, `service_status`, etc.) are unaffected and continue to update every poll as normal.

### Result

All service-level sensors now update once per day, simultaneously, when GloBird's data is fully confirmed — matching the timing of `latest_data_date`.

---

## 2. Missing icon for Expected Monthly Cost (`sensor.py`)

Changed the icon for `GloBirdExpectedMonthlyCostSensor` from `mdi:cash-calendar` to `mdi:calendar-question`, due to cash-calendar not being in the HA standard icons (thus presenting as blank).

---

Changes tested in production HAOS 2026.6.2 environment over a multiple daily updates to confirm accuracy and stability.