### PR TITLE
meter upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ Service-level sensors include:
 - Latest data date
 - Recent usage total
 - Latest day usage
+- Latest interval usage
 - Recent solar export total
 - Latest day solar export
+- Latest interval solar export
 - Recent cost total
 - Latest daily cost
 - ZeroHero status
@@ -66,11 +68,17 @@ Service-level sensors include:
 - Billing period cost
 - Weather summary
 
-Recorder-safe daily summaries, the latest interval array, compact usage register totals, cost category totals, and incomplete cost days are exposed as sensor attributes. Daily usage and cost attributes keep the most recent rows and include count/truncation flags; full cached snapshots are available through Home Assistant diagnostics with sensitive fields redacted.
+Recorder-safe daily summaries, the latest interval arrays, compact usage register totals, cost category totals, and incomplete cost days are exposed as sensor attributes. Daily usage and cost attributes keep the most recent rows and include count/truncation flags; full cached snapshots are available through Home Assistant diagnostics with sensitive fields redacted.
+
+For smart-meter services, the integration also exposes first-class interval sensors for the latest import and solar-export interval values so Home Assistant can graph them like normal entity history.
 
 ## Updates and data freshness
 
 Home Assistant polls the GloBird portal every 30 minutes. You can also force a check with Home Assistant's standard **Update entity** action on any GloBird entity.
+
+Usage fetches currently request a 31-day window. When a meter has been replaced during that window, the integration prefers the live meter and can fall back to removed meters to recover older usage rows that still belong to the previous meter.
+
+For smart-meter usage, interval arrays from the fetched usage rows are also published into Home Assistant Recorder as external statistics. That allows historical interval points already available from the portal to be backfilled into HA instead of only starting from the moment the integration is installed.
 
 GloBird usage and cost data normally trails by at least one day, and the portal can publish a fixed supply-charge row before the rest of that day's usage/export rows are ready. To avoid showing that early partial value as the latest daily cost, the integration only advances Latest Daily Cost to the newest cost date that has more than the fixed `SUPPLY` row. If a newer incomplete date is visible from the portal, it is exposed in attributes on Latest Data Date and cost sensors as `latest_available_day`, `latest_available_day_complete`, and `incomplete_days`.
 

--- a/custom_components/globird_ha/api.py
+++ b/custom_components/globird_ha/api.py
@@ -260,11 +260,11 @@ def service_id(service: dict[str, Any]) -> str:
     return str(value or "unknown")
 
 
-def select_meter_for_service(
+def meters_for_service(
     service: dict[str, Any],
     meters_payload: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Select the best available meter row for a service."""
+) -> list[dict[str, Any]]:
+    """Return candidate meter rows for a service."""
     raw = _payload_data(meters_payload)
 
     # API may return the list directly or wrapped in a nested dict
@@ -278,19 +278,106 @@ def select_meter_for_service(
                 meters = val
                 break
     else:
-        return None
+        return []
 
     if not meters:
-        return None
+        return []
 
     identifier = str(service.get("siteIdentifier") or "")
     if identifier:
         matched = [
-            m for m in meters
+            m
+            for m in meters
             if str(m.get("siteIdentifier") or m.get("nmi") or "") == identifier
         ]
         if matched:
-            meters = matched
+            return matched
+
+    return meters
+
+
+def usage_requires_history_fallback(
+    usage_payload: dict[str, Any] | None,
+    *,
+    days: int,
+    grace_days: int = 2,
+    today: date | None = None,
+) -> bool:
+    """Return whether usage data appears to be missing early days in the window."""
+    rows = _payload_data(usage_payload)
+    if not isinstance(rows, list) or not rows:
+        return True
+
+    read_dates = {
+        parsed
+        for parsed in (_parse_date(row.get("readDate")) for row in rows)
+        if parsed is not None
+    }
+    if not read_dates:
+        return False
+
+    today = today or date.today()
+    expected_start = today - timedelta(days=days)
+    earliest = min(read_dates)
+    return earliest > (expected_start + timedelta(days=grace_days))
+
+
+def merge_usage_payloads(
+    primary: dict[str, Any] | None,
+    secondary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Merge two usage payloads and de-duplicate overlapping rows."""
+    if not isinstance(primary, dict):
+        return secondary if isinstance(secondary, dict) else primary
+    if not isinstance(secondary, dict):
+        return primary
+
+    primary_rows = _payload_data(primary)
+    secondary_rows = _payload_data(secondary)
+    if not isinstance(primary_rows, list) or not isinstance(secondary_rows, list):
+        return primary
+
+    merged = dict(primary)
+    seen: set[tuple[str, str, str, str, str, str]] = set()
+    combined: list[dict[str, Any]] = []
+
+    for row in [*primary_rows, *secondary_rows]:
+        if not isinstance(row, dict):
+            continue
+        key = (
+            str(row.get("readDate") or ""),
+            str(row.get("suffix") or ""),
+            str(row.get("chargeType") or ""),
+            str(row.get("chargeCategoryCode") or ""),
+            str(row.get("serial") or ""),
+            str(row.get("usage") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        combined.append(row)
+
+    combined.sort(
+        key=lambda row: (
+            _parse_date(row.get("readDate")) or date.min,
+            str(row.get("suffix") or ""),
+            str(row.get("chargeType") or ""),
+        )
+    )
+
+    merged["data"] = combined
+    merged["success"] = bool(primary.get("success", True) and secondary.get("success", True))
+    return merged
+
+
+def select_meter_for_service(
+    service: dict[str, Any],
+    meters_payload: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Select the best available meter row for a service."""
+    meters = meters_for_service(service, meters_payload)
+    if not meters:
+        return None
 
     def _status_value(row: dict[str, Any]) -> str:
         return str(row.get("serialStatus") or "").strip().lower()

--- a/custom_components/globird_ha/api.py
+++ b/custom_components/globird_ha/api.py
@@ -560,6 +560,55 @@ def build_usage_summary(
     }
 
 
+def build_usage_interval_daily_series(
+    usage_payload: dict[str, Any] | None,
+    *,
+    direction: str,
+) -> list[dict[str, Any]]:
+    """Return per-day interval arrays for import or export usage.
+
+    Rows are grouped by readDate and interval arrays are summed element-wise
+    across all matching rows for that day.
+    """
+    rows = _payload_data(usage_payload)
+    if not isinstance(rows, list):
+        return []
+
+    if direction == "export":
+        selected_rows = [row for row in rows if _is_export_register(row)]
+    else:
+        selected_rows = [row for row in rows if not _is_export_register(row)]
+
+    by_date: dict[str, list[float]] = {}
+    for row in selected_rows:
+        read_date = str(row.get("readDate") or "")
+        interval_values = row.get("usageArray")
+        if not read_date or not isinstance(interval_values, list) or not interval_values:
+            continue
+
+        normalized = [(_as_float(value) or 0.0) for value in interval_values]
+        existing = by_date.get(read_date)
+        if existing is None:
+            by_date[read_date] = normalized
+            continue
+
+        if len(existing) < len(normalized):
+            existing.extend([0.0] * (len(normalized) - len(existing)))
+        for idx, value in enumerate(normalized):
+            existing[idx] += value
+
+    series: list[dict[str, Any]] = []
+    for read_date in sorted(by_date):
+        series.append(
+            {
+                "readDate": read_date,
+                "intervals": [_round(value, 5) for value in by_date[read_date]],
+            }
+        )
+
+    return series
+
+
 def build_cost_summary(cost_payload: dict[str, Any] | None) -> dict[str, Any]:
     """Build recorder-safe cost summary."""
     rows = _payload_data(cost_payload)

--- a/custom_components/globird_ha/api.py
+++ b/custom_components/globird_ha/api.py
@@ -171,7 +171,8 @@ def usage_attributes(
         "registers": registers,
     }
     if include_latest_intervals:
-        attrs["latest_intervals"] = summary.get("latest_intervals", [])
+        interval_key = "latest_export_intervals" if direction == "export" else "latest_intervals"
+        attrs["latest_intervals"] = summary.get(interval_key, [])
     return attrs
 
 
@@ -534,6 +535,7 @@ def build_usage_summary(
             "total_export": None,
             "latest_day_export": None,
             "export_daily": [],
+            "latest_export_intervals": [],
             "registers": [],
         }
 
@@ -553,6 +555,7 @@ def build_usage_summary(
         "total_export": export_summary["total"],
         "latest_day_export": export_summary["latest_day_usage"],
         "export_daily": export_summary["daily"],
+        "latest_export_intervals": export_summary["latest_intervals"],
         "registers": _build_usage_register_summaries(rows),
     }
 

--- a/custom_components/globird_ha/api.py
+++ b/custom_components/globird_ha/api.py
@@ -292,11 +292,30 @@ def select_meter_for_service(
         if matched:
             meters = matched
 
+    def _status_value(row: dict[str, Any]) -> str:
+        return str(row.get("serialStatus") or "").strip().lower()
+
+    def _is_smart_meter(row: dict[str, Any]) -> bool:
+        return str(row.get("meterReadType") or "").strip().lower() == "smart"
+
+    # Portal values vary across accounts/meter migrations. Prefer live meters first.
     active_meters = [
-        m for m in meters
-        if str(m.get("serialStatus") or "").lower() in ("", "active", "current")
+        m
+        for m in meters
+        if _status_value(m) in ("", "active", "current", "energized")
     ]
-    return active_meters[0] if active_meters else meters[0]
+    candidates = active_meters if active_meters else meters
+
+    non_removed = [
+        m
+        for m in candidates
+        if _status_value(m) not in ("removed", "inactive", "retired", "deenergized")
+    ]
+    if non_removed:
+        candidates = non_removed
+
+    smart_candidates = [m for m in candidates if _is_smart_meter(m)]
+    return smart_candidates[0] if smart_candidates else candidates[0]
 
 
 def _build_register_summary(

--- a/custom_components/globird_ha/api.py
+++ b/custom_components/globird_ha/api.py
@@ -314,7 +314,8 @@ def usage_requires_history_fallback(
         if parsed is not None
     }
     if not read_dates:
-        return False
+        # All dates unparseable — treat the same as having no rows: trigger fallback.
+        return True
 
     today = today or date.today()
     expected_start = today - timedelta(days=days)

--- a/custom_components/globird_ha/coordinator.py
+++ b/custom_components/globird_ha/coordinator.py
@@ -16,8 +16,11 @@ from .api import (
     build_usage_summary,
     build_weather_summary,
     extract_accounts_and_services,
+    merge_usage_payloads,
+    meters_for_service,
     select_meter_for_service,
     service_id,
+    usage_requires_history_fallback,
 )
 from .const import (
     ACCOUNT_UPDATE_INTERVAL,
@@ -220,12 +223,14 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         service_status = status_map.get(sid) if isinstance(status_map, dict) else None
 
+        all_meters = meters_for_service(service, meters_payload)
         meter = select_meter_for_service(service, meters_payload)
         identifier = service.get("siteIdentifier")
         serial_number = meter.get("serialNumber") if meter else None
         meter_read_type = str(meter.get("meterReadType") or "" if meter else "")
         is_smart = meter_read_type.lower() != "basic"
         account_service_id = service.get("accountServiceId")
+        usage_meter_serials: list[str] = [str(serial_number)] if serial_number else []
 
         usage = None
         if identifier and serial_number:
@@ -240,6 +245,50 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ),
                 cache,
             )
+
+            if usage_requires_history_fallback(usage, days=DEFAULT_USAGE_DAYS):
+                selected_serial = str(serial_number)
+                removed_statuses = {
+                    "removed",
+                    "inactive",
+                    "retired",
+                    "deenergized",
+                }
+
+                removed_meters = [
+                    candidate
+                    for candidate in all_meters
+                    if str(candidate.get("serialNumber") or "") != selected_serial
+                    and str(candidate.get("serialStatus") or "").strip().lower() in removed_statuses
+                ]
+
+                for fallback_meter in removed_meters:
+                    fallback_serial = str(fallback_meter.get("serialNumber") or "")
+                    if not fallback_serial:
+                        continue
+
+                    fallback_is_smart = (
+                        str(fallback_meter.get("meterReadType") or "").strip().lower() != "basic"
+                    )
+                    fallback_usage = await self._fetch_optional(
+                        f"usage_fallback_{fallback_serial}",
+                        lambda: self.client.get_usage(
+                            identifier=str(identifier),
+                            serial_number=fallback_serial,
+                            account_service_id=account_service_id,
+                            is_smart=fallback_is_smart,
+                            days=DEFAULT_USAGE_DAYS,
+                        ),
+                        cache,
+                    )
+                    usage = merge_usage_payloads(usage, fallback_usage)
+                    usage_meter_serials.append(fallback_serial)
+
+                    if not usage_requires_history_fallback(
+                        usage,
+                        days=DEFAULT_USAGE_DAYS,
+                    ):
+                        break
 
         cost = None
         if identifier and account_service_id:
@@ -271,6 +320,8 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "service": service,
             "status": service_status,
             "meter": meter,
+            "usage_meter_serials": usage_meter_serials,
+            "usage_fallback_applied": len(usage_meter_serials) > 1,
             "usage": usage,
             "usage_summary": build_usage_summary(usage),
             "cost": cost,

--- a/custom_components/globird_ha/coordinator.py
+++ b/custom_components/globird_ha/coordinator.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable
+from zoneinfo import ZoneInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,6 +15,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .api import (
     GloBirdClient,
     build_cost_summary,
+    build_usage_interval_daily_series,
     build_usage_summary,
     build_weather_summary,
     extract_accounts_and_services,
@@ -58,6 +61,7 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass, STORAGE_VERSION, f"{DOMAIN}.cookies.{entry.entry_id}"
         )
         self._cache: dict[str, Any] | None = None
+        self._interval_backfill_cursor: dict[str, str] = {}
         self._initialized = False
 
     async def async_shutdown(self) -> None:
@@ -71,6 +75,9 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         loaded_cache = await self._cache_store.async_load()
         self._cache = loaded_cache if isinstance(loaded_cache, dict) else None
+        cursor = self._cache.get("interval_backfill_cursor") if isinstance(self._cache, dict) else None
+        self._interval_backfill_cursor = cursor if isinstance(cursor, dict) else {}
+
         cookie_state = await self._cookie_store.async_load()
         cookies = cookie_state.get("cookies", []) if isinstance(cookie_state, dict) else []
         if isinstance(cookies, list) and cookies:
@@ -188,9 +195,11 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     data.get("read_meters"),
                     data.get("service_status"),
                     cached_detail if isinstance(cached_detail, dict) else {},
+                    self._interval_backfill_cursor,
                 )
 
             data["service_data"] = service_data
+            data["interval_backfill_cursor"] = self._interval_backfill_cursor
 
             self._cache = data
             await self._cache_store.async_save(data)
@@ -207,12 +216,146 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return stale
             raise UpdateFailed(f"Unable to fetch GloBird data: {err}") from err
 
+    @staticmethod
+    def _parse_portal_date(value: Any) -> datetime | None:
+        """Return midnight datetime for supported portal date formats."""
+        if not value:
+            return None
+        raw = str(value).split("T")[0]
+        for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+            try:
+                return datetime.strptime(raw, fmt)
+            except ValueError:
+                continue
+        return None
+
+    def _build_interval_statistics_points(
+        self,
+        series: list[dict[str, Any]],
+        *,
+        since_utc: datetime | None,
+    ) -> tuple[list[dict[str, Any]], datetime | None]:
+        """Build external-statistics points from daily interval arrays."""
+        tz_name = self.hass.config.time_zone or "UTC"
+        try:
+            local_tz = ZoneInfo(tz_name)
+        except Exception:  # noqa: BLE001 - fallback to UTC when timezone is invalid.
+            local_tz = timezone.utc
+
+        points: list[dict[str, Any]] = []
+        newest_point: datetime | None = None
+
+        for day_row in series:
+            day = self._parse_portal_date(day_row.get("readDate"))
+            intervals = day_row.get("intervals")
+            if day is None or not isinstance(intervals, list) or not intervals:
+                continue
+
+            interval_step = timedelta(seconds=(24 * 60 * 60) / len(intervals))
+            day_start = datetime.combine(day.date(), datetime.min.time(), tzinfo=local_tz)
+            for idx, interval_value in enumerate(intervals):
+                if not isinstance(interval_value, (int, float)):
+                    continue
+                start_utc = (day_start + interval_step * idx).astimezone(timezone.utc)
+                if since_utc is not None and start_utc <= since_utc:
+                    continue
+
+                value = float(interval_value)
+                points.append(
+                    {
+                        "start": start_utc,
+                        "mean": value,
+                        "min": value,
+                        "max": value,
+                    }
+                )
+                if newest_point is None or start_utc > newest_point:
+                    newest_point = start_utc
+
+        return points, newest_point
+
+    @staticmethod
+    def _parse_cursor_timestamp(value: str | None) -> datetime | None:
+        """Parse a persisted UTC timestamp cursor."""
+        if not value:
+            return None
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        return parsed.astimezone(timezone.utc) if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+    async def _publish_usage_interval_backfill(
+        self,
+        service: dict[str, Any],
+        usage_payload: dict[str, Any] | None,
+        interval_backfill_cursor: dict[str, str],
+    ) -> dict[str, Any]:
+        """Publish historical interval usage into Home Assistant external statistics."""
+        if not isinstance(usage_payload, dict):
+            return {
+                "import_points": 0,
+                "export_points": 0,
+                "updated": False,
+            }
+
+        try:
+            from homeassistant.components.recorder.statistics import (  # pylint: disable=import-outside-toplevel
+                async_add_external_statistics,
+            )
+        except Exception:  # noqa: BLE001 - recorder/statistics may be unavailable.
+            return {
+                "import_points": 0,
+                "export_points": 0,
+                "updated": False,
+                "reason": "recorder_unavailable",
+            }
+
+        sid = service_id(service)
+        totals = {
+            "import_points": 0,
+            "export_points": 0,
+            "updated": False,
+        }
+
+        for direction in ("import", "export"):
+            cursor_key = f"{sid}:{direction}"
+            since_utc = self._parse_cursor_timestamp(interval_backfill_cursor.get(cursor_key))
+            series = build_usage_interval_daily_series(usage_payload, direction=direction)
+            points, newest = self._build_interval_statistics_points(series, since_utc=since_utc)
+            if not points:
+                continue
+
+            statistic_id = f"{DOMAIN}:{sid}:{direction}_interval_kwh"
+            metadata = {
+                "has_mean": True,
+                "has_sum": False,
+                "name": f"GloBird {sid} {direction.title()} Interval Usage",
+                "source": DOMAIN,
+                "statistic_id": statistic_id,
+                "unit_of_measurement": "kWh",
+            }
+
+            try:
+                await async_add_external_statistics(self.hass, metadata, points)
+            except Exception as err:  # noqa: BLE001 - statistics import should not fail refresh.
+                _LOGGER.debug("Unable to publish interval backfill for %s: %s", statistic_id, err)
+                continue
+
+            totals[f"{direction}_points"] = len(points)
+            totals["updated"] = True
+            if newest is not None:
+                interval_backfill_cursor[cursor_key] = newest.isoformat()
+
+        return totals
+
     async def _fetch_service_detail(
         self,
         service: dict[str, Any],
         meters_payload: dict[str, Any] | None,
         status_payload: dict[str, Any] | None,
         cache: dict[str, Any],
+        interval_backfill_cursor: dict[str, str],
     ) -> dict[str, Any]:
         """Fetch heavier per-service detail."""
         sid = service_id(service)
@@ -290,6 +433,12 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     ):
                         break
 
+        usage_backfill = await self._publish_usage_interval_backfill(
+            service,
+            usage,
+            interval_backfill_cursor,
+        )
+
         cost = None
         if identifier and account_service_id:
             cost = await self._fetch_optional(
@@ -322,6 +471,7 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "meter": meter,
             "usage_meter_serials": usage_meter_serials,
             "usage_fallback_applied": len(usage_meter_serials) > 1,
+            "usage_backfill": usage_backfill,
             "usage": usage,
             "usage_summary": build_usage_summary(usage),
             "cost": cost,

--- a/custom_components/globird_ha/manifest.json
+++ b/custom_components/globird_ha/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bolagnaise/globird-ha/issues",
-  "version": "0.1.32"
+  "version": "0.1.33"
 }

--- a/custom_components/globird_ha/sensor.py
+++ b/custom_components/globird_ha/sensor.py
@@ -126,6 +126,16 @@ def _refresh_status_attrs(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _latest_interval_value(intervals: Any) -> float | None:
+    """Return the most recent interval value from an interval list."""
+    if not isinstance(intervals, list) or not intervals:
+        return None
+    last = intervals[-1]
+    if isinstance(last, (int, float)):
+        return float(last)
+    return None
+
+
 @dataclass(frozen=True)
 class GloBirdSensorDescription:
     """Description for a GloBird sensor."""
@@ -217,8 +227,10 @@ async def async_setup_entry(
                 GloBirdLatestDataDateSensor(coordinator, config_entry, service),
                 GloBirdUsageTotalSensor(coordinator, config_entry, service),
                 GloBirdLatestDayUsageSensor(coordinator, config_entry, service),
+                GloBirdLatestIntervalUsageSensor(coordinator, config_entry, service),
                 GloBirdSolarExportTotalSensor(coordinator, config_entry, service),
                 GloBirdLatestDaySolarExportSensor(coordinator, config_entry, service),
+                GloBirdLatestIntervalSolarExportSensor(coordinator, config_entry, service),
                 GloBirdCostTotalSensor(coordinator, config_entry, service),
                 GloBirdLatestDayCostSensor(coordinator, config_entry, service),
                 GloBirdZeroHeroStatusSensor(coordinator, config_entry, service),
@@ -517,6 +529,39 @@ class GloBirdLatestDayUsageSensor(GloBirdServiceBaseSensor):
         return attrs
 
 
+class GloBirdLatestIntervalUsageSensor(GloBirdServiceBaseSensor):
+    """Latest interval import usage sensor."""
+
+    sensor_key = "latest_interval_usage"
+    sensor_name = "Latest Interval Usage"
+    icon = "mdi:chart-timeline-variant"
+    native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    device_class = SensorDeviceClass.ENERGY
+    state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> Any:
+        """Return the latest import interval usage."""
+        summary = self._service_detail().get("usage_summary") or {}
+        return _latest_interval_value(summary.get("latest_intervals"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return interval metadata attributes."""
+        attrs = self._service_attrs()
+        summary = self._service_detail().get("usage_summary") or {}
+        intervals = summary.get("latest_intervals")
+        count = len(intervals) if isinstance(intervals, list) else 0
+        attrs.update(
+            {
+                "latest_day": summary.get("latest_day"),
+                "interval_count": count,
+                "interval_index": (count - 1) if count > 0 else None,
+            }
+        )
+        return attrs
+
+
 class GloBirdSolarExportTotalSensor(GloBirdServiceBaseSensor):
     """Recent solar export total sensor (B1 register)."""
 
@@ -561,7 +606,46 @@ class GloBirdLatestDaySolarExportSensor(GloBirdServiceBaseSensor):
         """Return latest day attributes."""
         attrs = self._service_attrs()
         summary = self._service_detail().get("usage_summary") or {}
-        attrs.update(usage_attributes(summary, direction="export"))
+        attrs.update(
+            usage_attributes(
+                summary,
+                direction="export",
+                include_latest_intervals=True,
+            )
+        )
+        return attrs
+
+
+class GloBirdLatestIntervalSolarExportSensor(GloBirdServiceBaseSensor):
+    """Latest interval solar export sensor."""
+
+    sensor_key = "latest_interval_solar_export"
+    sensor_name = "Latest Interval Solar Export"
+    icon = "mdi:solar-power-variant-outline"
+    native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    device_class = SensorDeviceClass.ENERGY
+    state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> Any:
+        """Return the latest export interval usage."""
+        summary = self._service_detail().get("usage_summary") or {}
+        return _latest_interval_value(summary.get("latest_export_intervals"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return interval metadata attributes."""
+        attrs = self._service_attrs()
+        summary = self._service_detail().get("usage_summary") or {}
+        intervals = summary.get("latest_export_intervals")
+        count = len(intervals) if isinstance(intervals, list) else 0
+        attrs.update(
+            {
+                "latest_day": summary.get("latest_day"),
+                "interval_count": count,
+                "interval_index": (count - 1) if count > 0 else None,
+            }
+        )
         return attrs
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,7 @@ build_weather_summary = api.build_weather_summary
 cost_attributes = api.cost_attributes
 extract_accounts_and_services = api.extract_accounts_and_services
 redact_sensitive = api.redact_sensitive
+select_meter_for_service = api.select_meter_for_service
 usage_attributes = api.usage_attributes
 
 
@@ -330,6 +331,47 @@ def test_usage_summary_tracks_all_registers_and_b_exports() -> None:
     assert usage["registers"][2]["chargeCategoryCode"] == "CONTROL"
 
 
+def test_select_meter_prefers_energized_smart_over_removed_basic() -> None:
+    """Meter selection should switch to an energized smart meter after upgrade."""
+    service = {"accountServiceId": 810964}
+    payload = {
+        "data": [
+            {
+                "meterReadType": "BASIC",
+                "serialNumber": "1180281",
+                "serialStatus": "Removed",
+            },
+            {
+                "meterReadType": "SMART",
+                "serialNumber": "LG12G055914",
+                "serialStatus": "Energized",
+            },
+        ]
+    }
+
+    meter = select_meter_for_service(service, payload)
+
+    assert meter is not None
+    assert meter["serialNumber"] == "LG12G055914"
+    assert meter["meterReadType"] == "SMART"
+
+
+def test_select_meter_prefers_smart_when_status_unknown() -> None:
+    """When statuses are empty, prefer the smart meter row."""
+    service = {"accountServiceId": 810964}
+    payload = {
+        "data": [
+            {"meterReadType": "BASIC", "serialNumber": "110563", "serialStatus": None},
+            {"meterReadType": "SMART", "serialNumber": "LG12G055914", "serialStatus": None},
+        ]
+    }
+
+    meter = select_meter_for_service(service, payload)
+
+    assert meter is not None
+    assert meter["meterReadType"] == "SMART"
+
+
 def test_cost_summary_exposes_new_category_totals() -> None:
     """Cost summaries preserve newer GloBird categories separately."""
     payload = {
@@ -503,6 +545,8 @@ def load_tests(
         test_cost_summary_net_daily_is_sum_not_last_row,
         test_cost_summary_ignores_supply_only_partial_latest_day,
         test_usage_summary_tracks_all_registers_and_b_exports,
+        test_select_meter_prefers_energized_smart_over_removed_basic,
+        test_select_meter_prefers_smart_when_status_unknown,
         test_cost_summary_exposes_new_category_totals,
         test_cost_summary_projects_current_month_cost,
         test_sensor_attributes_are_recorder_safe_summaries,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ GloBirdCaptchaRequired = api.GloBirdCaptchaRequired
 GloBirdAuthError = api.GloBirdAuthError
 GloBirdClient = api.GloBirdClient
 build_cost_summary = api.build_cost_summary
+build_usage_interval_daily_series = api.build_usage_interval_daily_series
 build_usage_summary = api.build_usage_summary
 build_weather_summary = api.build_weather_summary
 cost_attributes = api.cost_attributes
@@ -333,6 +334,36 @@ def test_usage_summary_tracks_all_registers_and_b_exports() -> None:
     ]
     assert usage["registers"][0]["direction"] == "export"
     assert usage["registers"][2]["chargeCategoryCode"] == "CONTROL"
+
+
+def test_build_usage_interval_daily_series_sums_by_day_and_direction() -> None:
+    """Interval series should aggregate rows per day and split import/export."""
+    payload = {
+        "data": [
+            {
+                "readDate": "2026/06/24",
+                "suffix": "E1",
+                "usageArray": [0.1, 0.2, 0.3],
+            },
+            {
+                "readDate": "2026/06/24",
+                "suffix": "E2",
+                "usageArray": [0.4, 0.5, 0.6],
+            },
+            {
+                "readDate": "2026/06/24",
+                "suffix": "B1",
+                "usageArray": [0.7, 0.8, 0.9],
+            },
+        ],
+        "success": True,
+    }
+
+    import_series = build_usage_interval_daily_series(payload, direction="import")
+    export_series = build_usage_interval_daily_series(payload, direction="export")
+
+    assert import_series == [{"readDate": "2026/06/24", "intervals": [0.5, 0.7, 0.9]}]
+    assert export_series == [{"readDate": "2026/06/24", "intervals": [0.7, 0.8, 0.9]}]
 
 
 def test_select_meter_prefers_energized_smart_over_removed_basic() -> None:
@@ -691,6 +722,7 @@ def load_tests(
         test_cost_summary_net_daily_is_sum_not_last_row,
         test_cost_summary_ignores_supply_only_partial_latest_day,
         test_usage_summary_tracks_all_registers_and_b_exports,
+        test_build_usage_interval_daily_series_sums_by_day_and_direction,
         test_select_meter_prefers_energized_smart_over_removed_basic,
         test_select_meter_prefers_smart_when_status_unknown,
         test_usage_requires_history_fallback_when_earliest_date_too_recent,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -206,6 +206,7 @@ def test_extract_accounts_services_and_summaries() -> None:
     assert usage["total_usage"] == 3.5
     assert usage["latest_day"] == "2026-04-02"
     assert usage["latest_intervals"] == [0.4, 0.5, 0.6]
+    assert usage["latest_export_intervals"] == []
     # Fixture: 2 days × (SOLAR + USAGE + SUPPLY). Net = (1.48) + (-0.43) = 1.05
     assert cost["total_amount"] == 1.05
     assert cost["total_quantity"] == 21.5
@@ -324,6 +325,7 @@ def test_usage_summary_tracks_all_registers_and_b_exports() -> None:
     assert usage["latest_day_usage"] == 4.0
     assert usage["total_export"] == 2.5
     assert usage["latest_day_export"] == 2.5
+    assert usage["latest_export_intervals"] == [1.5, 1.0]
     assert [register["key"] for register in usage["registers"]] == [
         "B2-Super Export",
         "E1-Peak",
@@ -629,6 +631,31 @@ def test_sensor_attributes_are_recorder_safe_summaries() -> None:
     assert len(json.dumps(cost)) < 16_384
 
 
+def test_usage_attributes_export_interval_source() -> None:
+    """Export usage attributes should surface export interval arrays when requested."""
+    summary = {
+        "export_daily": [{"readDate": "2026-04-24", "usage": 2.5}],
+        "registers": [
+            {
+                "key": "B2-Super Export",
+                "direction": "export",
+                "suffix": "B2",
+                "chargeType": "Super Export",
+                "chargeCategoryCode": "SOLAR",
+                "days": 1,
+                "total": 2.5,
+                "latest_day": "2026-04-24",
+                "latest_day_usage": 2.5,
+            }
+        ],
+        "latest_export_intervals": [1.5, 1.0],
+    }
+
+    attrs = usage_attributes(summary, direction="export", include_latest_intervals=True)
+
+    assert attrs["latest_intervals"] == [1.5, 1.0]
+
+
 def test_redact_sensitive_diagnostics() -> None:
     """Diagnostics redaction removes credentials and account identifiers."""
     payload = {
@@ -673,6 +700,7 @@ def load_tests(
         test_cost_summary_exposes_new_category_totals,
         test_cost_summary_projects_current_month_cost,
         test_sensor_attributes_are_recorder_safe_summaries,
+        test_usage_attributes_export_interval_source,
         test_redact_sensitive_diagnostics,
     ):
         suite.addTest(unittest.FunctionTestCase(test_func))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -418,6 +418,35 @@ def test_usage_requires_history_fallback_false_for_covered_window() -> None:
     ) is False
 
 
+def test_usage_requires_history_fallback_when_all_dates_unparseable() -> None:
+    """Fallback should trigger when rows exist but every readDate is unparseable."""
+    payload = {
+        "data": [
+            {
+                "readDate": None,
+                "usage": 1.0,
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+            },
+            {
+                "readDate": "not-a-date",
+                "usage": 2.0,
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+            },
+        ],
+        "success": True,
+    }
+
+    assert usage_requires_history_fallback(
+        payload,
+        days=31,
+        today=date(2026, 6, 22),
+    ) is True
+
+
 def test_merge_usage_payloads_combines_and_deduplicates_rows() -> None:
     """Merging usage payloads should keep unique rows and preserve chronological order."""
     primary = {
@@ -639,6 +668,7 @@ def load_tests(
         test_select_meter_prefers_smart_when_status_unknown,
         test_usage_requires_history_fallback_when_earliest_date_too_recent,
         test_usage_requires_history_fallback_false_for_covered_window,
+        test_usage_requires_history_fallback_when_all_dates_unparseable,
         test_merge_usage_payloads_combines_and_deduplicates_rows,
         test_cost_summary_exposes_new_category_totals,
         test_cost_summary_projects_current_month_cost,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,9 +33,11 @@ build_usage_summary = api.build_usage_summary
 build_weather_summary = api.build_weather_summary
 cost_attributes = api.cost_attributes
 extract_accounts_and_services = api.extract_accounts_and_services
+merge_usage_payloads = api.merge_usage_payloads
 redact_sensitive = api.redact_sensitive
 select_meter_for_service = api.select_meter_for_service
 usage_attributes = api.usage_attributes
+usage_requires_history_fallback = api.usage_requires_history_fallback
 
 
 def load_fixtures() -> dict[str, Any]:
@@ -372,6 +374,94 @@ def test_select_meter_prefers_smart_when_status_unknown() -> None:
     assert meter["meterReadType"] == "SMART"
 
 
+def test_usage_requires_history_fallback_when_earliest_date_too_recent() -> None:
+    """Fallback should trigger when the earliest usage date misses window start."""
+    payload = {
+        "data": [
+            {
+                "readDate": "2026/06/20",
+                "usage": 1.0,
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+            }
+        ],
+        "success": True,
+    }
+
+    assert usage_requires_history_fallback(
+        payload,
+        days=31,
+        today=date(2026, 6, 22),
+    ) is True
+
+
+def test_usage_requires_history_fallback_false_for_covered_window() -> None:
+    """Fallback should not trigger when usage starts near the requested window."""
+    payload = {
+        "data": [
+            {
+                "readDate": "2026/05/22",
+                "usage": 1.0,
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+            }
+        ],
+        "success": True,
+    }
+
+    assert usage_requires_history_fallback(
+        payload,
+        days=31,
+        today=date(2026, 6, 22),
+    ) is False
+
+
+def test_merge_usage_payloads_combines_and_deduplicates_rows() -> None:
+    """Merging usage payloads should keep unique rows and preserve chronological order."""
+    primary = {
+        "data": [
+            {
+                "readDate": "2026/06/20",
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+                "serial": "SMART1",
+                "usage": 2.0,
+            }
+        ],
+        "success": True,
+    }
+    fallback = {
+        "data": [
+            {
+                "readDate": "2026/06/18",
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+                "serial": "BASIC1",
+                "usage": 1.0,
+            },
+            {
+                "readDate": "2026/06/20",
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+                "serial": "SMART1",
+                "usage": 2.0,
+            },
+        ],
+        "success": True,
+    }
+
+    merged = merge_usage_payloads(primary, fallback)
+
+    assert merged is not None
+    assert [row["readDate"] for row in merged["data"]] == ["2026/06/18", "2026/06/20"]
+    assert len(merged["data"]) == 2
+
+
 def test_cost_summary_exposes_new_category_totals() -> None:
     """Cost summaries preserve newer GloBird categories separately."""
     payload = {
@@ -547,6 +637,9 @@ def load_tests(
         test_usage_summary_tracks_all_registers_and_b_exports,
         test_select_meter_prefers_energized_smart_over_removed_basic,
         test_select_meter_prefers_smart_when_status_unknown,
+        test_usage_requires_history_fallback_when_earliest_date_too_recent,
+        test_usage_requires_history_fallback_false_for_covered_window,
+        test_merge_usage_payloads_combines_and_deduplicates_rows,
         test_cost_summary_exposes_new_category_totals,
         test_cost_summary_projects_current_month_cost,
         test_sensor_attributes_are_recorder_safe_summaries,


### PR DESCRIPTION
- **Fix meter selection after basic-to-smart upgrades**
- **Add historical usage fallback across meter replacement**
- **fix: trigger history fallback when all readDate fields are unparseable**

Should fix #10 
