### PR TITLE
Fix latest_intervals double counting on time-of-use plans

### DIFF
--- a/custom_components/globird_ha/api.py
+++ b/custom_components/globird_ha/api.py
@@ -380,21 +380,15 @@ def _build_register_summary(
                 "usage": 0.0,
                 "meterStatus": row.get("meterStatus"),
                 "minQualityMethod": row.get("minQualityMethod"),
-                "intervals": None,
+                "register_arrays": {},
             }
         by_date[d]["usage"] += usage
-        # Element-wise sum of usageArrays across all time-of-use periods for the day
+        # Each time-of-use row repeats the register's full-day usageArray,
+        # so keep one array per register rather than summing rows together.
         arr = row.get("usageArray")
         if isinstance(arr, list) and arr:
-            existing = by_date[d]["intervals"]
-            if existing is None:
-                by_date[d]["intervals"] = list(arr)
-            else:
-                for i, v in enumerate(arr):
-                    if i < len(existing):
-                        existing[i] = (_as_float(existing[i]) or 0.0) + (
-                            _as_float(v) or 0.0
-                        )
+            register = (str(row.get("serial") or ""), str(row.get("suffix") or ""))
+            by_date[d]["register_arrays"].setdefault(register, arr)
 
     total = sum(v["usage"] for v in by_date.values())
     latest_date = max(by_date) if by_date else None
@@ -410,9 +404,18 @@ def _build_register_summary(
         for v in sorted(by_date.values(), key=lambda x: x["readDate"])
     ]
 
+    # Element-wise sum across distinct registers (e.g. E1 + controlled load E2).
     latest_intervals: list[Any] = []
-    if latest_entry and isinstance(latest_entry["intervals"], list):
-        latest_intervals = [_round(_as_float(v), 5) for v in latest_entry["intervals"]]
+    if latest_entry:
+        summed: list[float] = []
+        for arr in latest_entry["register_arrays"].values():
+            if not summed:
+                summed = [_as_float(v) or 0.0 for v in arr]
+            else:
+                for i, v in enumerate(arr):
+                    if i < len(summed):
+                        summed[i] += _as_float(v) or 0.0
+        latest_intervals = [_round(v, 5) for v in summed]
 
     return {
         "days": len(by_date),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -593,6 +593,51 @@ def test_usage_summary_tracks_all_registers_and_b_exports() -> None:
     assert usage["registers"][3]["direction"] == "export"
 
 
+def test_usage_summary_does_not_double_count_time_of_use_intervals() -> None:
+    """Time-of-use rows repeat the register's full-day usageArray; count it once per register."""
+    full_day_e1 = [1.0, 2.0, 1.5, 0.5]
+    payload = {
+        "data": [
+            {
+                "readDate": "2026-04-24",
+                "usage": 3.0,
+                "suffix": "E1",
+                "serial": "M1",
+                "chargeType": "Peak",
+                "chargeCategoryCode": "USAGE",
+                "usageArray": full_day_e1,
+            },
+            {
+                "readDate": "2026-04-24",
+                "usage": 2.0,
+                "suffix": "E1",
+                "serial": "M1",
+                "chargeType": "Off Peak",
+                "chargeCategoryCode": "USAGE",
+                "usageArray": full_day_e1,
+            },
+            {
+                "readDate": "2026-04-24",
+                "usage": 1.0,
+                "suffix": "E2",
+                "serial": "M1",
+                "chargeType": "Controlled Load",
+                "chargeCategoryCode": "CONTROL",
+                "usageArray": [0.25, 0.25, 0.25, 0.25],
+            },
+        ],
+        "message": None,
+        "success": True,
+    }
+
+    usage = build_usage_summary(payload)
+
+    assert usage["latest_day_usage"] == 6.0
+    assert usage["latest_intervals"] == [1.25, 2.25, 1.75, 0.75]
+    # Intervals must add up to the day's usage, not a multiple of it.
+    assert sum(usage["latest_intervals"]) == usage["latest_day_usage"]
+
+
 def test_cost_summary_exposes_new_category_totals() -> None:
     """Cost summaries preserve newer GloBird categories separately."""
     payload = {


### PR DESCRIPTION
On peak/off-peak plans the `latest_intervals` attribute reports roughly 2x the real usage (3x on three-period plans). Easy to check: `sum(latest_intervals)` should equal `latest_day_usage`, but it doesn't.

The portal sends one row per time-of-use period per day, and each row carries the same full-day `usageArray`. Only the scalar `usage` field is sliced to the period. So summing arrays across rows counts the whole day once per period. The portal's own chart code slices each row's array by its `timePeriods` rather than adding arrays together, which is how I confirmed it.

The fix takes the array once per register (serial + suffix) and still sums across different registers, so controlled load setups keep working. Single-rate plans aren't affected since they only get one row per day. Daily totals were already correct.

Added a regression test asserting `sum(latest_intervals) == latest_day_usage`.
