### PR TITLE
Fix TOU interval double-counting; import usage/cost into Energy Dashboard; add manual rate schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Account-level sensors include:
 - Dashboard balance and recent transactions
 - Latest invoice
 - Signup services
+- Weather impacted days
 - Last successful refresh
 - Refresh status
 - One account summary sensor per returned account
@@ -66,6 +67,7 @@ Service-level sensors include:
 - Billing period days
 - Billing period cost
 - Weather summary
+- Calculated TOU cost (only when a rate schedule is configured)
 
 Gas service-level sensors include:
 
@@ -73,10 +75,19 @@ Gas service-level sensors include:
 - Meter info
 - Latest gas reading
 - Latest gas reading date
+- Calculated gas cost (only when a rate schedule is configured)
 
-Recorder-safe daily summaries, the latest interval array, compact usage register totals, cost category totals, daily net cost totals, and incomplete cost days are exposed as sensor attributes. Daily usage and cost attributes keep the most recent rows and include count/truncation flags; full cached snapshots are available through Home Assistant diagnostics with sensitive fields redacted.
+Recorder-safe daily summaries, the latest interval array, a recent window of per-day half-hourly interval breakdowns, compact usage register totals (including any time-of-use split such as Peak/Offpeak), cost category totals, a cost breakdown by time-of-use charge type when the portal provides one, daily net cost totals, and incomplete cost days are exposed as sensor attributes. Daily usage and cost attributes keep the most recent rows and include count/truncation flags; full cached snapshots are available through Home Assistant diagnostics with sensitive fields redacted. Meter Info exposes a human-readable meter type description (e.g. "Smart") alongside the raw meter row.
 
 For gas services, historical basic-meter readings are also imported into Home Assistant recorder long-term statistics so historical charts can be populated from existing portal read history. Meter replacements and corrected lower reads are handled without losing subsequent consumption.
+
+For electricity import usage, smart-meter intervals across the cached usage window (up to 31 days) are imported into Home Assistant recorder long-term statistics under the Recent Usage Total sensor, aggregated to hourly resolution. Home Assistant's recorder rejects external statistics whose timestamp is not exactly on the hour, so even though GloBird reports finer-grained intervals (commonly every 5 or 30 minutes depending on the meter), each hour's intervals are summed before import; the finer-grained data is still available uncombined via the `intervals_by_day` attribute and feeds the Calculated TOU Cost sensor's per-interval accuracy. This lets the built-in Energy Dashboard show real hourly consumption shape, not just daily totals, and backfills as far back as GloBird has published interval data. Like all GloBird data, this trails the portal by roughly a day. Solar export intervals are not currently imported into statistics, only into daily totals.
+
+The portal attaches the same full-day interval array to every time-of-use row (e.g. Peak and Offpeak) for a meter, with only the billed portion differing per row; the integration counts each day's interval array once per meter register rather than once per time-of-use row, so time-of-use accounts don't get their interval data double-counted.
+
+Net daily cost is also imported into recorder long-term statistics under the Recent Cost Total sensor (daily resolution only, since GloBird does not publish half-hourly cost detail). Pair it with the Recent Usage Total statistic as the cost stat for grid consumption in the Energy Dashboard's settings to see $ alongside kWh.
+
+Both statistics imports are additive only: every sync re-uploads the currently cached ~31-day window, which upserts (adds or corrects) that window and backfills any day GloBird has newly published, but never deletes or touches statistics outside that window. History older than 31 days that was written by a previous sync is left untouched in Home Assistant's recorder and is only ever removed by your own recorder purge configuration or a manual statistics fix, never by this integration.
 
 ## Updates and data freshness
 
@@ -88,7 +99,38 @@ ZeroHero status reports the latest complete portal result as `achieved` or `miss
 
 Expected Monthly Cost projects the current billing period from completed daily net cost totals, using the latest invoice issue date as the billing-period start and a 30-day period. Billing Period Cost uses the same daily net totals so it matches the projection inputs. Billing Period Days uses Home Assistant's local date rather than the host process timezone.
 
-Pricing/rate-plan sensors are not currently exposed. The portal exposes product metadata, but not enough rate detail has been validated to provide EMHASS-ready import/export price sensors safely.
+Pricing/rate-plan sensors are not populated from the portal. GloBird's API exposes only product metadata (plan name, start/end date, a couple of flags) through `getProductsByAccountId` and `getAllProductHistoriesByAccountId` — verified directly, neither returns $/kWh rate figures — so there isn't enough rate detail available to derive prices automatically or safely provide EMHASS-ready import/export price sensors.
+
+Instead, you can enter your own time-of-use rate schedule (from your contract/bill) as JSON in the integration options to enable the **Calculated TOU Cost** sensor per electricity service. It stays unavailable until a schedule is configured. Example:
+
+```json
+{
+  "supply_charge": 1.12,
+  "periods": [
+    {"name": "Offpeak Usage", "rate": 0.28, "windows": [["00:00", "15:00"], ["21:00", "24:00"]]},
+    {"name": "Peak Usage", "rate": 0.45, "windows": [["15:00", "21:00"]]}
+  ]
+}
+```
+
+Each period's `windows` are `[start, end)` 24-hour clock pairs (`"24:00"` means midnight at the end of the day); `name` is just a label (matching your bill's chargeType names, e.g. "Peak Usage", makes the breakdown easier to read but isn't required for the calculation to work). The sensor state is the latest calculated day's total cost; attributes include the per-period kWh/cost breakdown, a recent daily history, and `unassigned_kwh` for any usage that fell outside all configured windows (a sign the schedule doesn't fully cover the day and should be adjusted). The calculation uses the same real per-interval usage that feeds the half-hourly statistics import, so it reflects actual consumption shape, not just a daily total split evenly across periods.
+
+Gas billing is shaped completely differently — a daily supply charge plus a seasonal, inclining-block `$/MJ` rate applied to *average* daily usage across each meter-read period (gas basic meters aren't read daily), and GloBird reports gas reads in the meter's native unit (typically m³), so a heating-value conversion factor to MJ is needed too. Enter this separately as gas rate schedule JSON in options to enable the **Calculated Gas Cost** sensor per gas service. Example, matching a typical GLOSAVE-style gas rate card:
+
+```json
+{
+  "daily_charge": 0.58685,
+  "conversion_mj_per_unit": 38.6,
+  "seasons": [
+    {"name": "Summer", "months": [10, 11, 12, 1, 2, 3],
+     "tiers": [{"limit_mj_per_day": 20.70, "rate": 0.03735}, {"limit_mj_per_day": null, "rate": 0.02934}]},
+    {"name": "Winter", "months": [4, 5, 6, 7, 8, 9],
+     "tiers": [{"limit_mj_per_day": 20.70, "rate": 0.03735}, {"limit_mj_per_day": null, "rate": 0.02934}]}
+  ]
+}
+```
+
+`conversion_mj_per_unit` is the heating value for your network (check your gas bill — it's usually printed there, and varies by distributor, roughly 37.7–39.3 MJ/m³). Tiers apply in order to average daily MJ usage for that read period; a `limit_mj_per_day` of `null` means "the remainder" and should only appear on the last tier. The sensor state is the most recently completed meter-read period's total cost (daily charge + tiered usage cost); attributes include a recent history of billed periods.
 
 ## Notes
 

--- a/custom_components/globird_ha/api.py
+++ b/custom_components/globird_ha/api.py
@@ -152,6 +152,7 @@ def usage_attributes(
     *,
     direction: str,
     include_latest_intervals: bool = False,
+    include_intervals_by_day: bool = False,
 ) -> dict[str, Any]:
     """Return recorder-safe usage attributes for import or export sensors."""
     daily_key = "export_daily" if direction == "export" else "daily"
@@ -173,6 +174,16 @@ def usage_attributes(
     }
     if include_latest_intervals:
         attrs["latest_intervals"] = summary.get("latest_intervals", [])
+    if include_intervals_by_day:
+        intervals_by_day = summary.get("intervals_by_day", [])
+        intervals_by_day_rows = (
+            intervals_by_day if isinstance(intervals_by_day, list) else []
+        )
+        attrs["intervals_by_day"] = _recent_rows(intervals_by_day_rows)
+        attrs["intervals_by_day_count"] = len(intervals_by_day_rows)
+        attrs["intervals_by_day_truncated"] = (
+            len(intervals_by_day_rows) > ATTR_RECENT_ROW_LIMIT
+        )
     return attrs
 
 
@@ -197,6 +208,24 @@ def cost_attributes(summary: dict[str, Any]) -> dict[str, Any]:
         "available_daily_count": len(available_rows),
         "available_daily_truncated": len(available_rows) > ATTR_RECENT_ROW_LIMIT,
         "categories": summary.get("categories", []),
+        "charge_type_totals": summary.get("charge_type_totals", []),
+    }
+
+
+def calculated_cost_attributes(summary: dict[str, Any]) -> dict[str, Any]:
+    """Return recorder-safe calculated (rate-schedule based) cost attributes."""
+    daily = summary.get("daily", [])
+    daily_rows = daily if isinstance(daily, list) else []
+    latest = daily_rows[-1] if daily_rows else None
+    return {
+        "days": summary.get("days", 0),
+        "latest_day": summary.get("latest_day"),
+        "total_cost": summary.get("total_cost"),
+        "latest_day_periods": latest.get("periods", []) if latest else [],
+        "latest_day_unassigned_kwh": latest.get("unassigned_kwh") if latest else None,
+        "daily": _recent_rows(daily_rows),
+        "daily_count": len(daily_rows),
+        "daily_truncated": len(daily_rows) > ATTR_RECENT_ROW_LIMIT,
     }
 
 
@@ -304,6 +333,19 @@ def _meter_type_rank(meter: dict[str, Any]) -> int:
     return 0
 
 
+def meter_type_description(
+    meter_types_payload: dict[str, Any] | None,
+    serial_number: Any,
+) -> str | None:
+    """Look up a human-readable meter type (e.g. 'Smart') by serial number."""
+    if not serial_number:
+        return None
+    lookup = _payload_data(meter_types_payload)
+    if not isinstance(lookup, dict):
+        return None
+    return lookup.get(str(serial_number))
+
+
 def select_meter_for_service(
     service: dict[str, Any],
     meters_payload: dict[str, Any] | None,
@@ -355,9 +397,13 @@ def _build_register_summary(
 ) -> dict[str, Any]:
     """Summarise a list of usage rows for a single register (E1 or B1).
 
-    Each day has multiple rows (one per time-of-use period). Group by date
-    so that daily totals and latest_day_usage are correct sums, not a single
-    time-of-use period's value.
+    Each day has multiple rows (one per time-of-use period, e.g. Peak/Offpeak).
+    Group by date so that daily totals and latest_day_usage are correct sums,
+    not a single time-of-use period's value. The portal attaches the *same*
+    full-day usageArray to every time-of-use row for a given suffix (only the
+    scalar `usage` differs per period), so interval arrays must be taken once
+    per (date, suffix) pair rather than summed across TOU rows, or they end
+    up double- (or triple-) counted for time-of-use tariffs.
     """
     if not rows:
         return {
@@ -371,6 +417,7 @@ def _build_register_summary(
 
     # Group rows by date
     by_date: dict[str, dict[str, Any]] = {}
+    seen_interval_keys: set[tuple[str, str]] = set()
     for row in rows:
         d = row.get("readDate") or ""
         usage = _as_float(row.get("usage")) or 0.0
@@ -383,9 +430,15 @@ def _build_register_summary(
                 "intervals": None,
             }
         by_date[d]["usage"] += usage
-        # Element-wise sum of usageArrays across all time-of-use periods for the day
+
         arr = row.get("usageArray")
-        if isinstance(arr, list) and arr:
+        interval_key = (d, str(row.get("suffix") or ""))
+        if (
+            isinstance(arr, list)
+            and arr
+            and interval_key not in seen_interval_keys
+        ):
+            seen_interval_keys.add(interval_key)
             existing = by_date[d]["intervals"]
             if existing is None:
                 by_date[d]["intervals"] = list(arr)
@@ -414,6 +467,15 @@ def _build_register_summary(
     if latest_entry and isinstance(latest_entry["intervals"], list):
         latest_intervals = [_round(_as_float(v), 5) for v in latest_entry["intervals"]]
 
+    intervals_by_day = [
+        {
+            "readDate": v["readDate"],
+            "intervals": [_round(_as_float(x), 5) for x in v["intervals"]],
+        }
+        for v in sorted(by_date.values(), key=lambda x: x["readDate"])
+        if isinstance(v["intervals"], list)
+    ]
+
     return {
         "days": len(by_date),
         "total": _round(total),
@@ -421,6 +483,7 @@ def _build_register_summary(
         "latest_day_usage": _round(latest_entry["usage"]) if latest_entry else None,
         "daily": daily,
         "latest_intervals": latest_intervals,
+        "intervals_by_day": intervals_by_day,
     }
 
 
@@ -494,6 +557,7 @@ def build_usage_summary(
             "latest_day_usage": None,
             "daily": [],
             "latest_intervals": [],
+            "intervals_by_day": [],
             "total_export": None,
             "latest_day_export": None,
             "export_daily": [],
@@ -513,6 +577,7 @@ def build_usage_summary(
         "latest_day_usage": import_summary["latest_day_usage"],
         "daily": import_summary["daily"],
         "latest_intervals": import_summary["latest_intervals"],
+        "intervals_by_day": import_summary["intervals_by_day"],
         "total_export": export_summary["total"],
         "latest_day_export": export_summary["latest_day_usage"],
         "export_daily": export_summary["daily"],
@@ -587,6 +652,7 @@ def build_cost_summary(cost_payload: dict[str, Any] | None) -> dict[str, Any]:
     daily_totals: dict[str, float] = {}
     available_daily: list[dict[str, Any]] = []
     categories: dict[str, dict[str, Any]] = {}
+    charge_types: dict[str, dict[str, Any]] = {}
     total_amount = 0.0
     total_quantity = 0.0
     grouped_rows: dict[str, list[dict[str, Any]]] = {}
@@ -630,6 +696,19 @@ def build_cost_summary(cost_payload: dict[str, Any] | None) -> dict[str, Any]:
             }
         categories[category]["amount"] += amount
         categories[category]["quantity"] += quantity
+
+        charge_type = row.get("chargeType")
+        if charge_type:
+            charge_type_key = str(charge_type).strip()
+            if charge_type_key not in charge_types:
+                charge_types[charge_type_key] = {
+                    "chargeType": charge_type,
+                    "amount": 0.0,
+                    "quantity": 0.0,
+                }
+            charge_types[charge_type_key]["amount"] += amount
+            charge_types[charge_type_key]["quantity"] += quantity
+
         daily.append(item)
 
     # GloBird returns multiple rows per day (SOLAR, USAGE, SUPPLY, etc.). Sum all
@@ -677,6 +756,14 @@ def build_cost_summary(cost_payload: dict[str, Any] | None) -> dict[str, Any]:
                 "quantity": _round(value["quantity"]),
             }
             for _, value in sorted(categories.items())
+        ],
+        "charge_type_totals": [
+            {
+                "chargeType": value["chargeType"],
+                "amount": _round(value["amount"], 2),
+                "quantity": _round(value["quantity"]),
+            }
+            for _, value in sorted(charge_types.items())
         ],
     }
 
@@ -799,6 +886,397 @@ def _build_projected_month_summary(
         "completed_days": completed_days,
         "days_in_month": days_in_month,
         "latest_day": latest_day.isoformat(),
+    }
+
+
+def _parse_clock_minutes(value: Any) -> int:
+    """Parse an HH:MM clock string into minutes since midnight (24:00 -> 1440)."""
+    raw = str(value).strip()
+    parts = raw.split(":")
+    if len(parts) < 2:
+        raise ValueError(f"Invalid time '{value}'")
+    hour = int(parts[0])
+    minute = int(parts[1])
+    if hour == 24 and minute == 0:
+        return 1440
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"Invalid time '{value}'")
+    return hour * 60 + minute
+
+
+def parse_tou_rate_schedule(raw: str | None) -> dict[str, Any] | None:
+    """Parse and validate a user-configured time-of-use rate schedule.
+
+    GloBird's API does not expose usable $/kWh rate data, so a schedule
+    entered from the customer's own contract/bill is the only source. Expected
+    shape (rates in $/kWh, supply_charge in $/day, windows as [start, end)
+    24-hour clock pairs, "24:00" meaning midnight at the end of the day)::
+
+        {
+            "supply_charge": 1.12,
+            "periods": [
+                {"name": "Offpeak Usage", "rate": 0.28,
+                 "windows": [["00:00", "15:00"], ["21:00", "24:00"]]},
+                {"name": "Peak Usage", "rate": 0.45,
+                 "windows": [["15:00", "21:00"]]}
+            ]
+        }
+
+    `name` should match the usage register's chargeType (e.g. "Peak Usage")
+    so the breakdown lines up with what the portal itself reports, but it is
+    only used as a label here - the windows are what select the rate.
+
+    Returns None when raw is empty/not configured. Raises ValueError for
+    malformed input so callers can surface a clear config error.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+
+    parsed = json.loads(text)
+    if not isinstance(parsed, dict):
+        raise ValueError("TOU rate schedule must be a JSON object")
+
+    periods_raw = parsed.get("periods")
+    if not isinstance(periods_raw, list) or not periods_raw:
+        raise ValueError("TOU rate schedule must include a non-empty 'periods' list")
+
+    periods: list[dict[str, Any]] = []
+    for period in periods_raw:
+        if not isinstance(period, dict):
+            raise ValueError("Each TOU period must be a JSON object")
+        name = str(period.get("name") or "").strip()
+        rate = _as_float(period.get("rate"))
+        windows_raw = period.get("windows")
+        if (
+            not name
+            or rate is None
+            or not isinstance(windows_raw, list)
+            or not windows_raw
+        ):
+            raise ValueError(f"Invalid TOU period: {period!r}")
+
+        windows: list[tuple[int, int]] = []
+        for window in windows_raw:
+            if not isinstance(window, (list, tuple)) or len(window) != 2:
+                raise ValueError(f"Invalid TOU window: {window!r}")
+            start = _parse_clock_minutes(window[0])
+            end = _parse_clock_minutes(window[1])
+            if end <= start:
+                raise ValueError(f"TOU window end must be after start: {window!r}")
+            windows.append((start, end))
+
+        periods.append({"name": name, "rate": rate, "windows": windows})
+
+    supply_charge = _as_float(parsed.get("supply_charge")) or 0.0
+    return {"supply_charge": supply_charge, "periods": periods}
+
+
+def calculate_tou_cost(
+    intervals_by_day: list[dict[str, Any]],
+    schedule: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Calculate estimated daily cost from interval usage and a TOU rate schedule."""
+    empty: dict[str, Any] = {
+        "days": 0,
+        "daily": [],
+        "latest_day": None,
+        "latest_day_cost": None,
+        "total_cost": None,
+    }
+    if not schedule or not isinstance(intervals_by_day, list):
+        return empty
+
+    periods = schedule.get("periods") or []
+    supply_charge = schedule.get("supply_charge") or 0.0
+
+    daily: list[dict[str, Any]] = []
+    for row in intervals_by_day:
+        if not isinstance(row, dict):
+            continue
+        read_date = row.get("readDate")
+        intervals = row.get("intervals")
+        if not read_date or not isinstance(intervals, list) or not intervals:
+            continue
+
+        minutes_per_interval = 1440 // len(intervals)
+        period_totals: dict[str, dict[str, Any]] = {
+            period["name"]: {"kwh": 0.0, "cost": 0.0, "rate": period["rate"]}
+            for period in periods
+        }
+        unassigned_kwh = 0.0
+
+        for index, value in enumerate(intervals):
+            usage = _as_float(value) or 0.0
+            interval_start = index * minutes_per_interval
+            matched = next(
+                (
+                    period
+                    for period in periods
+                    if any(
+                        start <= interval_start < end
+                        for start, end in period["windows"]
+                    )
+                ),
+                None,
+            )
+            if matched is None:
+                unassigned_kwh += usage
+                continue
+            bucket = period_totals[matched["name"]]
+            bucket["kwh"] += usage
+            bucket["cost"] += usage * matched["rate"]
+
+        usage_cost = sum(bucket["cost"] for bucket in period_totals.values())
+        total_cost = usage_cost + supply_charge
+
+        daily.append(
+            {
+                "readDate": read_date,
+                "total_cost": _round(total_cost, 2),
+                "usage_cost": _round(usage_cost, 2),
+                "supply_charge": _round(supply_charge, 2),
+                "unassigned_kwh": _round(unassigned_kwh, 3),
+                "periods": [
+                    {
+                        "name": name,
+                        "kwh": _round(bucket["kwh"], 3),
+                        "cost": _round(bucket["cost"], 2),
+                        "rate": bucket["rate"],
+                    }
+                    for name, bucket in period_totals.items()
+                ],
+            }
+        )
+
+    if not daily:
+        return empty
+
+    daily.sort(key=lambda row: row["readDate"])
+    latest = daily[-1]
+    return {
+        "days": len(daily),
+        "daily": daily,
+        "latest_day": latest["readDate"],
+        "latest_day_cost": latest["total_cost"],
+        "total_cost": _round(sum(row["total_cost"] for row in daily), 2),
+    }
+
+
+def parse_gas_rate_schedule(raw: str | None) -> dict[str, Any] | None:
+    """Parse and validate a user-configured gas rate schedule.
+
+    Gas billing shapes nothing like electricity time-of-use: it is a daily
+    charge plus a seasonal, inclining-block $/MJ rate applied to *average*
+    daily usage across the meter read period (gas basic meters are read
+    periodically, not daily, so retailers bill on the average). GloBird
+    reports gas meter reads in the read unit (typically m3), so a heating
+    value conversion factor to MJ is required. Expected shape::
+
+        {
+            "daily_charge": 0.58685,
+            "conversion_mj_per_unit": 38.6,
+            "seasons": [
+                {"name": "Summer", "months": [10, 11, 12, 1, 2, 3],
+                 "tiers": [{"limit_mj_per_day": 20.70, "rate": 0.03735},
+                           {"limit_mj_per_day": null, "rate": 0.02934}]},
+                {"name": "Winter", "months": [4, 5, 6, 7, 8, 9],
+                 "tiers": [{"limit_mj_per_day": 20.70, "rate": 0.03735},
+                           {"limit_mj_per_day": null, "rate": 0.02934}]}
+            ]
+        }
+
+    Tiers apply in order to average daily MJ usage; a `limit_mj_per_day` of
+    null means "the remainder" and should only appear on the last tier.
+
+    Returns None when raw is empty/not configured. Raises ValueError for
+    malformed input so callers can surface a clear config error.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+
+    parsed = json.loads(text)
+    if not isinstance(parsed, dict):
+        raise ValueError("Gas rate schedule must be a JSON object")
+
+    seasons_raw = parsed.get("seasons")
+    if not isinstance(seasons_raw, list) or not seasons_raw:
+        raise ValueError("Gas rate schedule must include a non-empty 'seasons' list")
+
+    seasons: list[dict[str, Any]] = []
+    for season in seasons_raw:
+        if not isinstance(season, dict):
+            raise ValueError("Each gas season must be a JSON object")
+
+        months_raw = season.get("months")
+        if not isinstance(months_raw, list) or not months_raw:
+            raise ValueError(f"Invalid gas season months: {season!r}")
+        months: list[int] = []
+        for value in months_raw:
+            month = int(value)
+            if not (1 <= month <= 12):
+                raise ValueError(f"Invalid month '{value}' in gas season: {season!r}")
+            months.append(month)
+
+        tiers_raw = season.get("tiers")
+        if not isinstance(tiers_raw, list) or not tiers_raw:
+            raise ValueError(f"Invalid gas season tiers: {season!r}")
+        tiers: list[dict[str, Any]] = []
+        for tier in tiers_raw:
+            if not isinstance(tier, dict):
+                raise ValueError(f"Invalid gas tier: {tier!r}")
+            rate = _as_float(tier.get("rate"))
+            if rate is None:
+                raise ValueError(f"Invalid gas tier rate: {tier!r}")
+            limit_raw = tier.get("limit_mj_per_day")
+            limit = _as_float(limit_raw) if limit_raw is not None else None
+            tiers.append({"limit_mj_per_day": limit, "rate": rate})
+
+        seasons.append(
+            {
+                "name": str(season.get("name") or "").strip() or None,
+                "months": months,
+                "tiers": tiers,
+            }
+        )
+
+    conversion = _as_float(parsed.get("conversion_mj_per_unit"))
+    if conversion is None or conversion <= 0:
+        raise ValueError(
+            "Gas rate schedule must include a positive 'conversion_mj_per_unit'"
+        )
+    daily_charge = _as_float(parsed.get("daily_charge")) or 0.0
+
+    return {
+        "daily_charge": daily_charge,
+        "conversion_mj_per_unit": conversion,
+        "seasons": seasons,
+    }
+
+
+def _gas_season_for_date(day: date, seasons: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the configured season covering a given date's month."""
+    return next((season for season in seasons if day.month in season["months"]), None)
+
+
+def _gas_tiered_usage_cost(daily_mj: float, tiers: list[dict[str, Any]]) -> float:
+    """Apply inclining-block $/MJ tiers to an average daily MJ usage figure."""
+    remaining = daily_mj
+    cost = 0.0
+    for tier in tiers:
+        if remaining <= 0:
+            break
+        limit = tier["limit_mj_per_day"]
+        if limit is None:
+            cost += remaining * tier["rate"]
+            remaining = 0.0
+            break
+        take = min(remaining, limit)
+        cost += take * tier["rate"]
+        remaining -= take
+    return cost
+
+
+def calculate_gas_cost(
+    history: list[dict[str, Any]],
+    schedule: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Calculate estimated gas cost per meter-read period from a rate schedule.
+
+    Gas basic meters are read periodically (not daily), so each consecutive
+    pair of reads for the same meter becomes one billed period: usage is
+    converted to MJ, averaged over the days in that period, tiered per the
+    matching season, and a per-day supply charge is added for the period.
+    Meter replacements (a lower read on a new serial) are skipped rather
+    than treated as negative usage, mirroring the recorder statistics import.
+    """
+    empty: dict[str, Any] = {
+        "periods": [],
+        "latest_period_cost": None,
+        "total_cost": None,
+    }
+    if not schedule or not isinstance(history, list):
+        return empty
+
+    rows = sorted(
+        (
+            row
+            for row in history
+            if isinstance(row, dict)
+            and _parse_date(row.get("date")) is not None
+            and isinstance(row.get("read_index"), (int, float))
+        ),
+        key=lambda row: (str(row.get("date") or ""), str(row.get("serial") or "")),
+    )
+    if len(rows) < 2:
+        return empty
+
+    conversion = schedule["conversion_mj_per_unit"]
+    daily_charge = schedule.get("daily_charge") or 0.0
+    seasons = schedule.get("seasons") or []
+
+    meter_high_water: dict[str, float] = {}
+    periods: list[dict[str, Any]] = []
+    previous_row: dict[str, Any] | None = None
+
+    for row in rows:
+        reading = float(row["read_index"])
+        meter_key = str(row.get("serial") or "unknown")
+        previous_reading = meter_high_water.get(meter_key)
+        meter_high_water[meter_key] = (
+            reading if previous_reading is None else max(previous_reading, reading)
+        )
+
+        if previous_row is not None and previous_reading is not None and reading > previous_reading:
+            start_day = _parse_date(previous_row.get("date"))
+            end_day = _parse_date(row.get("date"))
+            days = (end_day - start_day).days if start_day and end_day else 0
+            if days > 0:
+                units_used = reading - previous_reading
+                mj_used = units_used * conversion
+                avg_daily_mj = mj_used / days
+                season = _gas_season_for_date(end_day, seasons)
+                if season is not None:
+                    usage_cost = _gas_tiered_usage_cost(avg_daily_mj, season["tiers"]) * days
+                    daily_charge_cost = daily_charge * days
+                    periods.append(
+                        {
+                            "start": start_day.isoformat(),
+                            "end": end_day.isoformat(),
+                            "days": days,
+                            "mj_used": _round(mj_used, 3),
+                            "avg_daily_mj": _round(avg_daily_mj, 3),
+                            "season": season.get("name"),
+                            "usage_cost": _round(usage_cost, 2),
+                            "daily_charge_cost": _round(daily_charge_cost, 2),
+                            "total_cost": _round(usage_cost + daily_charge_cost, 2),
+                        }
+                    )
+        previous_row = row
+
+    if not periods:
+        return empty
+
+    periods.sort(key=lambda period: period["end"])
+    latest = periods[-1]
+    return {
+        "periods": periods,
+        "latest_period_cost": latest["total_cost"],
+        "total_cost": _round(sum(period["total_cost"] for period in periods), 2),
+    }
+
+
+def gas_cost_attributes(summary: dict[str, Any]) -> dict[str, Any]:
+    """Return recorder-safe calculated gas cost attributes."""
+    periods = summary.get("periods", [])
+    periods = periods if isinstance(periods, list) else []
+    return {
+        "periods": len(periods),
+        "latest_period_cost": summary.get("latest_period_cost"),
+        "total_cost": summary.get("total_cost"),
+        "recent_periods": _recent_rows(periods),
+        "periods_truncated": len(periods) > ATTR_RECENT_ROW_LIMIT,
     }
 
 

--- a/custom_components/globird_ha/config_flow.py
+++ b/custom_components/globird_ha/config_flow.py
@@ -9,11 +9,19 @@ from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
-from .api import GloBirdAuthError, GloBirdCaptchaRequired, GloBirdClient
+from .api import (
+    GloBirdAuthError,
+    GloBirdCaptchaRequired,
+    GloBirdClient,
+    parse_gas_rate_schedule,
+    parse_tou_rate_schedule,
+)
 from .const import (
     CONF_DAILY_POLL_START_TIME,
     CONF_EMAIL,
+    CONF_GAS_RATE_SCHEDULE,
     CONF_PASSWORD,
+    CONF_TOU_RATE_SCHEDULE,
     DEFAULT_DAILY_POLL_START_TIME,
     DOMAIN,
 )
@@ -90,13 +98,29 @@ class GloBirdOptionsFlow(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage integration options."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            try:
+                parse_tou_rate_schedule(user_input.get(CONF_TOU_RATE_SCHEDULE))
+            except (ValueError, TypeError):
+                errors["base"] = "invalid_tou_rate_schedule"
+
+            if not errors:
+                try:
+                    parse_gas_rate_schedule(user_input.get(CONF_GAS_RATE_SCHEDULE))
+                except (ValueError, TypeError):
+                    errors["base"] = "invalid_gas_rate_schedule"
+
+            if not errors:
+                return self.async_create_entry(title="", data=user_input)
 
         current_time = self.config_entry.options.get(
             CONF_DAILY_POLL_START_TIME,
             DEFAULT_DAILY_POLL_START_TIME,
         )
+        current_tou_schedule = self.config_entry.options.get(CONF_TOU_RATE_SCHEDULE, "")
+        current_gas_schedule = self.config_entry.options.get(CONF_GAS_RATE_SCHEDULE, "")
 
         return self.async_show_form(
             step_id="init",
@@ -106,6 +130,25 @@ class GloBirdOptionsFlow(config_entries.OptionsFlow):
                         CONF_DAILY_POLL_START_TIME,
                         default=current_time,
                     ): selector.TimeSelector(),
+                    vol.Optional(
+                        CONF_TOU_RATE_SCHEDULE,
+                        default=current_tou_schedule,
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT,
+                            multiline=True,
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_GAS_RATE_SCHEDULE,
+                        default=current_gas_schedule,
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.TEXT,
+                            multiline=True,
+                        )
+                    ),
                 }
             ),
+            errors=errors,
         )

--- a/custom_components/globird_ha/const.py
+++ b/custom_components/globird_ha/const.py
@@ -10,6 +10,8 @@ CONF_EMAIL = "email"
 CONF_PASSWORD = "password"
 CONF_DAILY_POLL_START_TIME = "daily_poll_start_time"
 DEFAULT_DAILY_POLL_START_TIME = "00:05"
+CONF_TOU_RATE_SCHEDULE = "tou_rate_schedule"
+CONF_GAS_RATE_SCHEDULE = "gas_rate_schedule"
 
 BASE_URL = "https://myaccount.globirdenergy.com.au"
 

--- a/custom_components/globird_ha/coordinator.py
+++ b/custom_components/globird_ha/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Mapping
 from datetime import datetime, time as dt_time, timedelta
 from typing import Any, Awaitable, Callable
 
@@ -21,7 +22,12 @@ from .api import (
     build_latest_data_status,
     build_usage_summary,
     build_weather_summary,
+    calculate_gas_cost,
+    calculate_tou_cost,
     extract_accounts_and_services,
+    meter_type_description,
+    parse_gas_rate_schedule,
+    parse_tou_rate_schedule,
     select_meter_for_service,
     service_id,
 )
@@ -29,7 +35,9 @@ from .const import (
     ACCOUNT_UPDATE_INTERVAL,
     CONF_DAILY_POLL_START_TIME,
     CONF_EMAIL,
+    CONF_GAS_RATE_SCHEDULE,
     CONF_PASSWORD,
+    CONF_TOU_RATE_SCHEDULE,
     DEFAULT_DAILY_POLL_START_TIME,
     DEFAULT_USAGE_DAYS,
     DEFAULT_GAS_READING_DAYS,
@@ -108,10 +116,44 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         options = getattr(self.entry, "options", {})
         configured = (
             options.get(CONF_DAILY_POLL_START_TIME)
-            if isinstance(options, dict)
+            if isinstance(options, Mapping)
             else None
         )
         return _parse_daily_poll_start_time(configured)
+
+    def _parsed_tou_rate_schedule(self) -> tuple[dict[str, Any] | None, str | None]:
+        """Return the configured TOU rate schedule and any parse error message.
+
+        GloBird's API exposes no usable $/kWh rate data, so this is entered
+        manually in integration options. Invalid input degrades to "no
+        schedule" (calculated-cost sensors stay unavailable) rather than
+        failing the whole update.
+        """
+        options = getattr(self.entry, "options", {})
+        raw = (
+            options.get(CONF_TOU_RATE_SCHEDULE)
+            if isinstance(options, Mapping)
+            else None
+        )
+        try:
+            return parse_tou_rate_schedule(raw), None
+        except (ValueError, TypeError) as err:
+            _LOGGER.warning("GloBird TOU rate schedule is invalid: %s", err)
+            return None, str(err)
+
+    def _parsed_gas_rate_schedule(self) -> tuple[dict[str, Any] | None, str | None]:
+        """Return the configured gas rate schedule and any parse error message."""
+        options = getattr(self.entry, "options", {})
+        raw = (
+            options.get(CONF_GAS_RATE_SCHEDULE)
+            if isinstance(options, Mapping)
+            else None
+        )
+        try:
+            return parse_gas_rate_schedule(raw), None
+        except (ValueError, TypeError) as err:
+            _LOGGER.warning("GloBird gas rate schedule is invalid: %s", err)
+            return None, str(err)
 
     def _set_update_interval_for_data(self, data: dict[str, Any]) -> None:
         """Slow polling after all electricity services have the latest daily data."""
@@ -282,6 +324,11 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             finally:
                 self.client.enable_reauth()
 
+            tou_schedule, tou_schedule_error = self._parsed_tou_rate_schedule()
+            data["tou_schedule_error"] = tou_schedule_error
+            gas_schedule, gas_schedule_error = self._parsed_gas_rate_schedule()
+            data["gas_schedule_error"] = gas_schedule_error
+
             cached_service_data = cache.get("service_data", {})
             cached_service_data = (
                 cached_service_data if isinstance(cached_service_data, dict) else {}
@@ -294,6 +341,9 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     service,
                     data.get("read_meters"),
                     data.get("service_status"),
+                    data.get("meter_types"),
+                    tou_schedule,
+                    gas_schedule,
                     cached_detail if isinstance(cached_detail, dict) else {},
                 )
 
@@ -323,6 +373,9 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         service: dict[str, Any],
         meters_payload: dict[str, Any] | None,
         status_payload: dict[str, Any] | None,
+        meter_types_payload: dict[str, Any] | None,
+        tou_schedule: dict[str, Any] | None,
+        gas_schedule: dict[str, Any] | None,
         cache: dict[str, Any],
     ) -> dict[str, Any]:
         """Fetch heavier per-service detail."""
@@ -397,17 +450,32 @@ class GloBirdCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         usage_summary = build_usage_summary(usage) if not is_gas_service else {}
         gas_reading_summary = build_gas_reading_summary(usage) if is_gas_service else {}
         cost_summary = build_cost_summary(cost)
+        calculated_cost_summary = (
+            calculate_tou_cost(usage_summary.get("intervals_by_day", []), tou_schedule)
+            if not is_gas_service
+            else {}
+        )
+        calculated_gas_cost_summary = (
+            calculate_gas_cost(gas_reading_summary.get("history", []), gas_schedule)
+            if is_gas_service
+            else {}
+        )
 
         return {
             "service": service,
             "status": service_status,
             "meter": meter,
+            "meter_type_description": meter_type_description(
+                meter_types_payload, serial_number
+            ),
             "read_meters": service_meters,
             "usage": usage,
             "usage_summary": usage_summary,
             "gas_reading_summary": gas_reading_summary,
             "cost": cost,
             "cost_summary": cost_summary,
+            "calculated_cost_summary": calculated_cost_summary,
+            "calculated_gas_cost_summary": calculated_gas_cost_summary,
             "latest_data_status": build_latest_data_status(usage_summary, cost_summary),
             "weather": weather,
             "weather_summary": build_weather_summary(weather),

--- a/custom_components/globird_ha/sensor.py
+++ b/custom_components/globird_ha/sensor.py
@@ -24,12 +24,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
-from homeassistant.util.unit_conversion import VolumeConverter
+from homeassistant.util.unit_conversion import EnergyConverter, VolumeConverter
 
 from .api import (
     build_billing_period_projection,
     build_latest_data_status,
+    calculated_cost_attributes,
     cost_attributes,
+    gas_cost_attributes,
     service_id,
     usage_attributes,
 )
@@ -277,6 +279,103 @@ def _build_gas_statistics(
     return [by_day[day] for day in sorted(by_day)]
 
 
+def _build_usage_half_hourly_statistics(
+    intervals_by_day: list[dict[str, Any]],
+    *,
+    tzinfo: Any,
+) -> list[dict[str, Any]]:
+    """Build cumulative-sum hourly statistics from per-day usage intervals.
+
+    Home Assistant's recorder rejects external statistics whose `start` is
+    not exactly on the hour (minutes/seconds must be 0) -- external
+    statistics only support hourly resolution, regardless of how fine the
+    source interval data is. So sub-hourly intervals (GloBird reports 5- or
+    30-minute intervals depending on the meter) are summed into hourly
+    buckets here before being handed to the recorder; the finer-grained data
+    is still available raw via calculate_tou_cost and the intervals_by_day
+    attribute, just not through this statistics import.
+    """
+    rows = sorted(
+        (
+            row
+            for row in intervals_by_day
+            if isinstance(row, dict)
+            and _parse_portal_day(row.get("readDate")) is not None
+            and isinstance(row.get("intervals"), list)
+            and row.get("intervals")
+        ),
+        key=lambda row: str(row.get("readDate") or ""),
+    )
+    if not rows:
+        return []
+
+    hourly_usage: dict[datetime, float] = {}
+    for row in rows:
+        day = _parse_portal_day(row["readDate"])
+        intervals = row["intervals"]
+        minutes_per_interval = 1440 // len(intervals)
+        day_start = datetime.combine(day, dt_time.min, tzinfo=tzinfo)
+        for index, value in enumerate(intervals):
+            usage = float(value) if isinstance(value, (int, float)) else 0.0
+            interval_start = day_start + timedelta(minutes=index * minutes_per_interval)
+            hour_start = interval_start.replace(minute=0, second=0, microsecond=0)
+            hourly_usage[hour_start] = hourly_usage.get(hour_start, 0.0) + usage
+
+    statistics: list[dict[str, Any]] = []
+    cumulative_sum = 0.0
+    for hour_start in sorted(hourly_usage):
+        usage = hourly_usage[hour_start]
+        cumulative_sum += usage
+        statistics.append(
+            {
+                "start": hour_start,
+                "state": round(usage, 5),
+                "sum": round(cumulative_sum, 5),
+            }
+        )
+    return statistics
+
+
+def _build_daily_cost_statistics(
+    daily_totals: list[dict[str, Any]],
+    *,
+    tzinfo: Any,
+) -> list[dict[str, Any]]:
+    """Build cumulative-sum daily cost statistics from net daily cost totals.
+
+    GloBird's cost detail is only published at daily resolution (no
+    half-hourly breakdown), so this statistic is daily-granularity, unlike
+    the half-hourly usage statistics.
+    """
+    rows = sorted(
+        (
+            row
+            for row in daily_totals
+            if isinstance(row, dict)
+            and _parse_portal_day(row.get("date")) is not None
+            and isinstance(row.get("amount"), (int, float))
+        ),
+        key=lambda row: str(row.get("date") or ""),
+    )
+    if not rows:
+        return []
+
+    statistics: list[dict[str, Any]] = []
+    cumulative_sum = 0.0
+    for row in rows:
+        day = _parse_portal_day(row["date"])
+        amount = float(row["amount"])
+        cumulative_sum += amount
+        statistics.append(
+            {
+                "start": datetime.combine(day, dt_time.min, tzinfo=tzinfo),
+                "state": round(amount, 2),
+                "sum": round(cumulative_sum, 2),
+            }
+        )
+    return statistics
+
+
 def _zerohero_last_result(
     summary: dict[str, Any],
 ) -> tuple[str, date | None, str | None]:
@@ -319,6 +418,11 @@ def _next_zerohero_status_boundary(now: datetime) -> datetime:
 
 def _refresh_status_value(data: dict[str, Any]) -> str:
     return "error" if data.get("refresh_error") else "ok"
+
+
+def _weather_impacted_days_value(data: dict[str, Any]) -> Any:
+    payload = _payload_data(data.get("weather_impacted_days")) or {}
+    return payload.get("numberOfImpactedDays")
 
 
 def _refresh_status_attrs(data: dict[str, Any]) -> dict[str, Any]:
@@ -380,6 +484,12 @@ GLOBAL_SENSORS: tuple[GloBirdSensorDescription, ...] = (
         icon="mdi:transmission-tower",
     ),
     GloBirdSensorDescription(
+        key="weather_impacted_days",
+        name="Weather Impacted Days",
+        value_fn=_weather_impacted_days_value,
+        icon="mdi:weather-lightning-rainy",
+    ),
+    GloBirdSensorDescription(
         key="last_successful_refresh",
         name="Last Successful Refresh",
         value_fn=_last_successful_refresh_value,
@@ -428,6 +538,7 @@ async def async_setup_entry(
                         config_entry,
                         service,
                     ),
+                    GloBirdCalculatedGasCostSensor(coordinator, config_entry, service),
                 ]
             )
         else:
@@ -445,6 +556,7 @@ async def async_setup_entry(
                     ),
                     GloBirdCostTotalSensor(coordinator, config_entry, service),
                     GloBirdLatestDayCostSensor(coordinator, config_entry, service),
+                    GloBirdCalculatedCostSensor(coordinator, config_entry, service),
                     GloBirdZeroHeroStatusSensor(coordinator, config_entry, service),
                     GloBirdExpectedMonthlyCostSensor(
                         coordinator,
@@ -653,7 +765,9 @@ class GloBirdMeterInfoSensor(GloBirdServiceBaseSensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return meter attributes."""
         attrs = self._service_attrs()
-        attrs["meter"] = self._service_detail().get("meter")
+        detail = self._service_detail()
+        attrs["meter"] = detail.get("meter")
+        attrs["meter_type_description"] = detail.get("meter_type_description")
         return attrs
 
 
@@ -881,6 +995,48 @@ class GloBirdLatestGasReadingDateSensor(GloBirdServiceBaseSensor):
         return attrs
 
 
+class GloBirdCalculatedGasCostSensor(GloBirdServiceBaseSensor):
+    """Estimated gas cost calculated from meter reads and a user-configured
+    seasonal, tiered rate schedule.
+
+    GloBird's API exposes no usable gas rate data either, so this is
+    calculated locally from a rate schedule entered in integration options
+    (daily charge + seasonal $/MJ tiers) applied to average daily usage
+    across each meter-read period. Stays unavailable until a schedule is
+    configured.
+    """
+
+    sensor_key = "calculated_gas_cost"
+    sensor_name = "Calculated Gas Cost"
+    icon = "mdi:calculator-variant"
+    native_unit_of_measurement = CURRENCY_AUD
+    device_class = SensorDeviceClass.MONETARY
+    state_class = None
+
+    @property
+    def available(self) -> bool:
+        """Only available once a gas rate schedule is configured and valid."""
+        summary = self._service_detail().get("calculated_gas_cost_summary") or {}
+        return bool(summary.get("periods"))
+
+    @property
+    def native_value(self) -> Any:
+        """Return the most recent billed period's total cost."""
+        summary = self._service_detail().get("calculated_gas_cost_summary") or {}
+        return summary.get("latest_period_cost")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return calculated gas cost breakdown attributes."""
+        attrs = self._service_attrs()
+        summary = self._service_detail().get("calculated_gas_cost_summary") or {}
+        attrs.update(gas_cost_attributes(summary))
+        attrs["schedule_error"] = (self.coordinator.data or {}).get(
+            "gas_schedule_error"
+        )
+        return attrs
+
+
 class GloBirdUsageTotalSensor(GloBirdServiceBaseSensor):
     """Recent usage total sensor."""
 
@@ -890,6 +1046,90 @@ class GloBirdUsageTotalSensor(GloBirdServiceBaseSensor):
     native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     device_class = SensorDeviceClass.ENERGY
     state_class = SensorStateClass.TOTAL
+
+    async def async_added_to_hass(self) -> None:
+        """Upload historical half-hourly usage to recorder long-term statistics."""
+        await super().async_added_to_hass()
+        await self._async_upload_historical_statistics()
+
+    def _handle_coordinator_update(self) -> None:
+        """Refresh the entity and import any newly published usage intervals."""
+        super()._handle_coordinator_update()
+        self.hass.async_create_task(self._async_upload_historical_statistics())
+
+    async def _async_upload_historical_statistics(self) -> None:
+        """Import all cached half-hourly usage as external statistics."""
+        summary = self._service_detail().get("usage_summary") or {}
+        intervals_by_day = summary.get("intervals_by_day")
+        if not isinstance(intervals_by_day, list) or not intervals_by_day:
+            _LOGGER.debug(
+                "GloBird usage statistics import skipped for %s (%s): "
+                "no interval data available",
+                self._service_id,
+                getattr(self, "_attr_unique_id", self._service_id),
+            )
+            return
+
+        try:
+            from homeassistant.components.recorder.statistics import (
+                StatisticData,
+                StatisticMetaData,
+                async_add_external_statistics,
+            )
+        except ImportError:
+            return
+
+        statistics = [
+            StatisticData(**row)
+            for row in _build_usage_half_hourly_statistics(
+                intervals_by_day,
+                tzinfo=dt_util.now().tzinfo or timezone.utc,
+            )
+        ]
+
+        if not statistics:
+            _LOGGER.debug(
+                "GloBird usage statistics import skipped for %s (%s): "
+                "no valid interval rows after parsing",
+                self._service_id,
+                getattr(self, "_attr_unique_id", self._service_id),
+            )
+            return
+
+        statistic_suffix = _safe_statistic_id(
+            getattr(self, "_attr_unique_id", self._service_id),
+            self._service_id,
+        )
+        statistic_id = f"{DOMAIN}:{statistic_suffix}"
+        metadata = StatisticMetaData(
+            has_mean=False,
+            mean_type=StatisticMeanType.NONE,
+            has_sum=True,
+            name=self._attr_name,
+            source=DOMAIN,
+            statistic_id=statistic_id,
+            unit_class=EnergyConverter.UNIT_CLASS,
+            unit_of_measurement=self.native_unit_of_measurement,
+        )
+        _LOGGER.debug(
+            "GloBird usage statistics prepared for %s (%s): %d rows from %s to %s",
+            self._service_id,
+            statistic_id,
+            len(statistics),
+            statistics[0]["start"].isoformat(),
+            statistics[-1]["start"].isoformat(),
+        )
+        try:
+            add_result = async_add_external_statistics(self.hass, metadata, statistics)
+            if isawaitable(add_result):
+                await add_result
+        except Exception as err:  # noqa: BLE001 - statistics import is best-effort.
+            _LOGGER.warning(
+                "GloBird usage statistics import skipped for %s (%s): %s",
+                self._service_id,
+                statistic_id,
+                err,
+            )
 
     @property
     def native_value(self) -> Any:
@@ -901,7 +1141,13 @@ class GloBirdUsageTotalSensor(GloBirdServiceBaseSensor):
         """Return usage summary attributes."""
         attrs = self._service_attrs()
         summary = self._service_detail().get("usage_summary") or {}
-        attrs.update(usage_attributes(summary, direction="import"))
+        attrs.update(
+            usage_attributes(
+                summary,
+                direction="import",
+                include_intervals_by_day=True,
+            )
+        )
         return attrs
 
 
@@ -997,6 +1243,95 @@ class GloBirdCostTotalSensor(GloBirdServiceBaseSensor):
     device_class = SensorDeviceClass.MONETARY
     state_class = None
 
+    async def async_added_to_hass(self) -> None:
+        """Upload historical daily cost to recorder long-term statistics."""
+        await super().async_added_to_hass()
+        await self._async_upload_historical_statistics()
+
+    def _handle_coordinator_update(self) -> None:
+        """Refresh the entity and import any newly published daily cost."""
+        super()._handle_coordinator_update()
+        self.hass.async_create_task(self._async_upload_historical_statistics())
+
+    async def _async_upload_historical_statistics(self) -> None:
+        """Import all cached net daily cost totals as external statistics.
+
+        Usable as the Energy Dashboard's cost statistic for the matching
+        usage statistic on the Recent Usage Total sensor. Daily resolution
+        only, since GloBird's cost detail is not published half-hourly.
+        """
+        summary = self._service_detail().get("cost_summary") or {}
+        daily_totals = summary.get("daily_totals")
+        if not isinstance(daily_totals, list) or not daily_totals:
+            _LOGGER.debug(
+                "GloBird cost statistics import skipped for %s (%s): "
+                "no daily cost totals available",
+                self._service_id,
+                getattr(self, "_attr_unique_id", self._service_id),
+            )
+            return
+
+        try:
+            from homeassistant.components.recorder.statistics import (
+                StatisticData,
+                StatisticMetaData,
+                async_add_external_statistics,
+            )
+        except ImportError:
+            return
+
+        statistics = [
+            StatisticData(**row)
+            for row in _build_daily_cost_statistics(
+                daily_totals,
+                tzinfo=dt_util.now().tzinfo or timezone.utc,
+            )
+        ]
+
+        if not statistics:
+            _LOGGER.debug(
+                "GloBird cost statistics import skipped for %s (%s): "
+                "no valid daily cost rows after parsing",
+                self._service_id,
+                getattr(self, "_attr_unique_id", self._service_id),
+            )
+            return
+
+        statistic_suffix = _safe_statistic_id(
+            getattr(self, "_attr_unique_id", self._service_id),
+            self._service_id,
+        )
+        statistic_id = f"{DOMAIN}:{statistic_suffix}"
+        metadata = StatisticMetaData(
+            has_mean=False,
+            mean_type=StatisticMeanType.NONE,
+            has_sum=True,
+            name=self._attr_name,
+            source=DOMAIN,
+            statistic_id=statistic_id,
+            unit_class=None,
+            unit_of_measurement=self.native_unit_of_measurement,
+        )
+        _LOGGER.debug(
+            "GloBird cost statistics prepared for %s (%s): %d rows from %s to %s",
+            self._service_id,
+            statistic_id,
+            len(statistics),
+            statistics[0]["start"].isoformat(),
+            statistics[-1]["start"].isoformat(),
+        )
+        try:
+            add_result = async_add_external_statistics(self.hass, metadata, statistics)
+            if isawaitable(add_result):
+                await add_result
+        except Exception as err:  # noqa: BLE001 - statistics import is best-effort.
+            _LOGGER.warning(
+                "GloBird cost statistics import skipped for %s (%s): %s",
+                self._service_id,
+                statistic_id,
+                err,
+            )
+
     @property
     def native_value(self) -> Any:
         """Return total recent cost."""
@@ -1042,6 +1377,53 @@ class GloBirdLatestDayCostSensor(GloBirdServiceBaseSensor):
                 ),
                 "zerohero_credit": summary.get("latest_day_zerohero_credit"),
             }
+        )
+        return attrs
+
+
+class GloBirdCalculatedCostSensor(GloBirdServiceBaseSensor):
+    """Estimated cost calculated from usage intervals and a user-configured
+    time-of-use rate schedule.
+
+    GloBird's API does not expose usable $/kWh rate data (verified against
+    both getProductsByAccountId and getAllProductHistoriesByAccountId, which
+    only return plan name/dates/flags, no rate figures), so this is
+    calculated locally from a rate schedule entered in integration options
+    and the already-deduplicated per-interval usage. Stays unavailable until
+    a schedule is configured.
+    """
+
+    sensor_key = "calculated_cost"
+    sensor_name = "Calculated TOU Cost"
+    icon = "mdi:calculator-variant"
+    native_unit_of_measurement = CURRENCY_AUD
+    device_class = SensorDeviceClass.MONETARY
+    state_class = None
+
+    @property
+    def available(self) -> bool:
+        """Only available once a TOU rate schedule is configured and valid.
+
+        Matches this integration's existing pattern elsewhere of trusting
+        cached/stale data rather than gating on coordinator update success.
+        """
+        summary = self._service_detail().get("calculated_cost_summary") or {}
+        return bool(summary.get("days"))
+
+    @property
+    def native_value(self) -> Any:
+        """Return the latest calculated day's total cost."""
+        summary = self._service_detail().get("calculated_cost_summary") or {}
+        return summary.get("latest_day_cost")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return calculated cost breakdown attributes."""
+        attrs = self._service_attrs()
+        summary = self._service_detail().get("calculated_cost_summary") or {}
+        attrs.update(calculated_cost_attributes(summary))
+        attrs["schedule_error"] = (self.coordinator.data or {}).get(
+            "tou_schedule_error"
         )
         return attrs
 

--- a/custom_components/globird_ha/strings.json
+++ b/custom_components/globird_ha/strings.json
@@ -24,11 +24,17 @@
     "step": {
       "init": {
         "title": "GloBird HA options",
-        "description": "Set when automatic daily readiness polling resumes after the previous day is ready.",
+        "description": "Set when automatic daily readiness polling resumes after the previous day is ready. GloBird's API exposes no usable rate data, so pricing must come from your own contract/bill: optionally enter a time-of-use electricity rate schedule and/or a seasonal tiered gas rate schedule, both as JSON, to enable the Calculated TOU Cost and Calculated Gas Cost sensors - see the README for the expected format of each. Leave a field blank to leave its sensor unavailable.",
         "data": {
-          "daily_poll_start_time": "Daily polling start time"
+          "daily_poll_start_time": "Daily polling start time",
+          "tou_rate_schedule": "Electricity time-of-use rate schedule (JSON, optional)",
+          "gas_rate_schedule": "Gas rate schedule (JSON, optional)"
         }
       }
+    },
+    "error": {
+      "invalid_tou_rate_schedule": "Time-of-use rate schedule is not valid JSON or is missing required fields",
+      "invalid_gas_rate_schedule": "Gas rate schedule is not valid JSON or is missing required fields"
     }
   },
   "entity": {
@@ -83,6 +89,15 @@
       },
       "latest_day_cost": {
         "name": "Latest Daily Cost"
+      },
+      "calculated_cost": {
+        "name": "Calculated TOU Cost"
+      },
+      "calculated_gas_cost": {
+        "name": "Calculated Gas Cost"
+      },
+      "weather_impacted_days": {
+        "name": "Weather Impacted Days"
       },
       "zerohero_status": {
         "name": "ZeroHero Status"

--- a/custom_components/globird_ha/translations/en.json
+++ b/custom_components/globird_ha/translations/en.json
@@ -24,11 +24,17 @@
     "step": {
       "init": {
         "title": "GloBird HA options",
-        "description": "Set when automatic daily readiness polling resumes after the previous day is ready.",
+        "description": "Set when automatic daily readiness polling resumes after the previous day is ready. GloBird's API exposes no usable rate data, so pricing must come from your own contract/bill: optionally enter a time-of-use electricity rate schedule and/or a seasonal tiered gas rate schedule, both as JSON, to enable the Calculated TOU Cost and Calculated Gas Cost sensors - see the README for the expected format of each. Leave a field blank to leave its sensor unavailable.",
         "data": {
-          "daily_poll_start_time": "Daily polling start time"
+          "daily_poll_start_time": "Daily polling start time",
+          "tou_rate_schedule": "Electricity time-of-use rate schedule (JSON, optional)",
+          "gas_rate_schedule": "Gas rate schedule (JSON, optional)"
         }
       }
+    },
+    "error": {
+      "invalid_tou_rate_schedule": "Time-of-use rate schedule is not valid JSON or is missing required fields",
+      "invalid_gas_rate_schedule": "Gas rate schedule is not valid JSON or is missing required fields"
     }
   },
   "entity": {
@@ -83,6 +89,15 @@
       },
       "latest_day_cost": {
         "name": "Latest Daily Cost"
+      },
+      "calculated_cost": {
+        "name": "Calculated TOU Cost"
+      },
+      "calculated_gas_cost": {
+        "name": "Calculated Gas Cost"
+      },
+      "weather_impacted_days": {
+        "name": "Weather Impacted Days"
       },
       "zerohero_status": {
         "name": "ZeroHero Status"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -593,6 +593,109 @@ def test_usage_summary_tracks_all_registers_and_b_exports() -> None:
     assert usage["registers"][3]["direction"] == "export"
 
 
+def test_usage_summary_retains_intervals_for_every_day() -> None:
+    """Half-hourly intervals are kept for all fetched days, not just the latest."""
+    payload = {
+        "data": [
+            {
+                "readDate": "2026-04-23",
+                "usage": 3.0,
+                "suffix": "E1",
+                "chargeType": "Peak",
+                "chargeCategoryCode": "USAGE",
+                "usageArray": [1.0, 2.0],
+            },
+            {
+                "readDate": "2026-04-24",
+                "usage": 5.0,
+                "suffix": "E1",
+                "chargeType": "Peak",
+                "chargeCategoryCode": "USAGE",
+                "usageArray": [2.0, 3.0],
+            },
+        ],
+        "message": None,
+        "success": True,
+    }
+
+    usage = build_usage_summary(payload)
+
+    assert usage["intervals_by_day"] == [
+        {"readDate": "2026-04-23", "intervals": [1.0, 2.0]},
+        {"readDate": "2026-04-24", "intervals": [2.0, 3.0]},
+    ]
+    # The latest-day-only attribute keeps working alongside the new full history.
+    assert usage["latest_intervals"] == [2.0, 3.0]
+
+
+def test_usage_attributes_expose_recent_intervals_by_day_when_requested() -> None:
+    """intervals_by_day is recorder-safe (truncated) and opt-in via a flag."""
+    payload = {
+        "data": [
+            {
+                "readDate": (date(2026, 4, 1) + timedelta(days=offset)).isoformat(),
+                "usage": 1.0,
+                "suffix": "E1",
+                "chargeType": "Peak",
+                "chargeCategoryCode": "USAGE",
+                "usageArray": [0.1] * 48,
+            }
+            for offset in range(10)
+        ],
+    }
+    summary = build_usage_summary(payload)
+
+    without_intervals = usage_attributes(summary, direction="import")
+    assert "intervals_by_day" not in without_intervals
+
+    with_intervals = usage_attributes(
+        summary, direction="import", include_intervals_by_day=True
+    )
+    assert with_intervals["intervals_by_day_count"] == 10
+    assert with_intervals["intervals_by_day_truncated"] is True
+    assert len(with_intervals["intervals_by_day"]) == 7
+    assert len(json.dumps(with_intervals)) < 16_384
+
+
+def test_usage_intervals_are_not_double_counted_across_tou_periods() -> None:
+    """The portal attaches the same full-day array to every TOU row for a
+    suffix; only the first occurrence per (date, suffix) should be counted,
+    or interval sums silently double for time-of-use tariffs."""
+    payload = {
+        "data": [
+            {
+                "readDate": "2026-09-01",
+                "usage": 2.482,
+                "suffix": "E1",
+                "chargeType": "Offpeak Usage",
+                "chargeCategoryCode": "USAGE",
+                "usageArray": [0.02, 0.024, 0.007],
+            },
+            {
+                "readDate": "2026-09-01",
+                "usage": 2.183,
+                "suffix": "E1",
+                "chargeType": "Peak Usage",
+                "chargeCategoryCode": "USAGE",
+                # Portal duplicates the same full-day array on every TOU row.
+                "usageArray": [0.02, 0.024, 0.007],
+            },
+        ],
+        "message": None,
+        "success": True,
+    }
+
+    usage = build_usage_summary(payload)
+
+    # Scalar usage totals correctly sum each TOU period's own portion.
+    assert usage["latest_day_usage"] == 4.665
+    # But the interval array must only be counted once, not once per TOU row.
+    assert usage["latest_intervals"] == [0.02, 0.024, 0.007]
+    assert usage["intervals_by_day"] == [
+        {"readDate": "2026-09-01", "intervals": [0.02, 0.024, 0.007]}
+    ]
+
+
 def test_cost_summary_exposes_new_category_totals() -> None:
     """Cost summaries preserve newer GloBird categories separately."""
     payload = {
@@ -638,6 +741,295 @@ def test_cost_summary_exposes_new_category_totals() -> None:
         {"chargeCategory": "USAGE", "amount": 1.2, "quantity": 3.0},
         {"chargeCategory": "ZEROHERO Credit", "amount": -0.3, "quantity": 0.0},
     ]
+
+
+def test_cost_summary_breaks_down_by_charge_type() -> None:
+    """Time-of-use charge types (Peak/Offpeak) are totalled separately when present."""
+    payload = {
+        "data": [
+            {
+                "chargeCategory": "USAGE",
+                "chargeType": "Peak Usage",
+                "date": "2026/09/01",
+                "amount": 2.18,
+                "quantity": 2.183,
+            },
+            {
+                "chargeCategory": "USAGE",
+                "chargeType": "Offpeak Usage",
+                "date": "2026/09/01",
+                "amount": 1.24,
+                "quantity": 2.482,
+            },
+            {
+                "chargeCategory": "SUPPLY",
+                "chargeType": None,
+                "date": "2026/09/01",
+                "amount": 1.12,
+                "quantity": 0.0,
+            },
+        ],
+        "message": None,
+        "success": True,
+    }
+
+    cost = build_cost_summary(payload)
+
+    assert cost["charge_type_totals"] == [
+        {"chargeType": "Offpeak Usage", "amount": 1.24, "quantity": 2.482},
+        {"chargeType": "Peak Usage", "amount": 2.18, "quantity": 2.183},
+    ]
+    assert cost_attributes(cost)["charge_type_totals"] == cost["charge_type_totals"]
+
+
+def test_cost_summary_charge_type_totals_empty_when_type_missing() -> None:
+    """Flat-rate plans with no chargeType on cost rows degrade to an empty list."""
+    payload = {
+        "data": [
+            {
+                "chargeCategory": "USAGE",
+                "chargeType": None,
+                "date": "2026/09/01",
+                "amount": 3.42,
+                "quantity": 4.665,
+            },
+        ],
+        "message": None,
+        "success": True,
+    }
+
+    cost = build_cost_summary(payload)
+
+    assert cost["charge_type_totals"] == []
+
+
+def test_parse_tou_rate_schedule_returns_none_when_blank() -> None:
+    """An unset/blank schedule means the calculated cost feature is disabled."""
+    assert api.parse_tou_rate_schedule(None) is None
+    assert api.parse_tou_rate_schedule("") is None
+    assert api.parse_tou_rate_schedule("   ") is None
+
+
+def test_parse_tou_rate_schedule_parses_windows_and_supply_charge() -> None:
+    """A valid schedule normalizes clock strings into minutes since midnight."""
+    schedule = api.parse_tou_rate_schedule(
+        json.dumps(
+            {
+                "supply_charge": 1.12,
+                "periods": [
+                    {
+                        "name": "Offpeak Usage",
+                        "rate": 0.28,
+                        "windows": [["00:00", "15:00"], ["21:00", "24:00"]],
+                    },
+                    {"name": "Peak Usage", "rate": 0.45, "windows": [["15:00", "21:00"]]},
+                ],
+            }
+        )
+    )
+
+    assert schedule["supply_charge"] == 1.12
+    assert schedule["periods"][0] == {
+        "name": "Offpeak Usage",
+        "rate": 0.28,
+        "windows": [(0, 900), (1260, 1440)],
+    }
+    assert schedule["periods"][1]["windows"] == [(900, 1260)]
+
+
+def test_parse_tou_rate_schedule_rejects_malformed_input() -> None:
+    """Malformed schedules raise ValueError so callers can surface a config error."""
+    for bad in (
+        "not json",
+        "[]",
+        json.dumps({"periods": []}),
+        json.dumps({"periods": [{"name": "Peak", "rate": 0.4}]}),
+        json.dumps(
+            {"periods": [{"name": "Peak", "rate": 0.4, "windows": [["21:00", "15:00"]]}]}
+        ),
+    ):
+        with unittest.TestCase().assertRaises(ValueError):
+            api.parse_tou_rate_schedule(bad)
+
+
+def test_calculate_tou_cost_splits_usage_by_configured_windows() -> None:
+    """Interval usage is bucketed into whichever configured window it falls in."""
+    schedule = api.parse_tou_rate_schedule(
+        json.dumps(
+            {
+                "supply_charge": 1.0,
+                "periods": [
+                    {"name": "Offpeak", "rate": 0.20, "windows": [["00:00", "12:00"]]},
+                    {"name": "Peak", "rate": 0.50, "windows": [["12:00", "24:00"]]},
+                ],
+            }
+        )
+    )
+    # 4 intervals/day => 6 hours each: [0-6h, 6-12h, 12-18h, 18-24h)
+    intervals_by_day = [
+        {"readDate": "2026-09-01", "intervals": [1.0, 1.0, 2.0, 2.0]},
+    ]
+
+    result = api.calculate_tou_cost(intervals_by_day, schedule)
+
+    assert result["days"] == 1
+    assert result["latest_day"] == "2026-09-01"
+    day = result["daily"][0]
+    # Offpeak: 1.0 + 1.0 = 2.0 kWh * 0.20 = 0.40; Peak: 2.0+2.0=4.0 kWh * 0.50 = 2.00
+    assert day["usage_cost"] == 2.40
+    assert day["total_cost"] == 3.40  # + 1.0 supply charge
+    assert day["unassigned_kwh"] == 0.0
+    periods_by_name = {p["name"]: p for p in day["periods"]}
+    assert periods_by_name["Offpeak"] == {"name": "Offpeak", "kwh": 2.0, "cost": 0.4, "rate": 0.20}
+    assert periods_by_name["Peak"] == {"name": "Peak", "kwh": 4.0, "cost": 2.0, "rate": 0.50}
+    assert result["total_cost"] == 3.40
+
+
+def test_calculate_tou_cost_tracks_unassigned_usage_outside_configured_windows() -> None:
+    """Usage outside any configured window is tracked, not silently dropped."""
+    schedule = api.parse_tou_rate_schedule(
+        json.dumps(
+            {
+                "periods": [
+                    {"name": "Evening", "rate": 0.40, "windows": [["18:00", "24:00"]]},
+                ],
+            }
+        )
+    )
+    intervals_by_day = [{"readDate": "2026-09-01", "intervals": [1.0, 1.0]}]
+
+    result = api.calculate_tou_cost(intervals_by_day, schedule)
+
+    day = result["daily"][0]
+    assert day["unassigned_kwh"] == 2.0
+    assert day["usage_cost"] == 0.0
+
+
+def test_calculate_tou_cost_returns_empty_without_a_schedule() -> None:
+    """No schedule configured means the calculated-cost feature stays disabled."""
+    result = api.calculate_tou_cost(
+        [{"readDate": "2026-09-01", "intervals": [1.0]}], None
+    )
+    assert result == {
+        "days": 0,
+        "daily": [],
+        "latest_day": None,
+        "latest_day_cost": None,
+        "total_cost": None,
+    }
+
+
+def test_parse_gas_rate_schedule_returns_none_when_blank() -> None:
+    """An unset/blank gas schedule means the calculated gas cost feature is disabled."""
+    assert api.parse_gas_rate_schedule(None) is None
+    assert api.parse_gas_rate_schedule("") is None
+
+
+def test_parse_gas_rate_schedule_requires_positive_conversion_factor() -> None:
+    """A missing or non-positive MJ conversion factor is rejected."""
+    for bad_conversion in (json.dumps({"seasons": [{"months": [1], "tiers": [{"rate": 0.1}]}]}),):
+        with unittest.TestCase().assertRaises(ValueError):
+            api.parse_gas_rate_schedule(bad_conversion)
+
+
+def test_calculate_gas_cost_applies_seasonal_tiered_rates_to_average_daily_usage() -> None:
+    """Real-world-shaped GLOSAVE gas rates applied over a 30-day read period."""
+    schedule = api.parse_gas_rate_schedule(
+        json.dumps(
+            {
+                "daily_charge": 0.58685,
+                "conversion_mj_per_unit": 38.6,
+                "seasons": [
+                    {
+                        "name": "Summer",
+                        "months": [10, 11, 12, 1, 2, 3],
+                        "tiers": [
+                            {"limit_mj_per_day": 20.70, "rate": 0.03735},
+                            {"limit_mj_per_day": None, "rate": 0.02934},
+                        ],
+                    },
+                    {
+                        "name": "Winter",
+                        "months": [4, 5, 6, 7, 8, 9],
+                        "tiers": [
+                            {"limit_mj_per_day": 20.70, "rate": 0.03735},
+                            {"limit_mj_per_day": None, "rate": 0.02934},
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+    history = [
+        {"date": "2026-08-01", "read_index": 100.0, "serial": "A"},
+        {"date": "2026-08-31", "read_index": 130.0, "serial": "A"},
+    ]
+
+    result = api.calculate_gas_cost(history, schedule)
+
+    assert result["periods"] == [
+        {
+            "start": "2026-08-01",
+            "end": "2026-08-31",
+            "days": 30,
+            "mj_used": 1158.0,
+            "avg_daily_mj": 38.6,
+            "season": "Winter",
+            "usage_cost": 38.95,
+            "daily_charge_cost": 17.61,
+            "total_cost": 56.56,
+        }
+    ]
+    assert result["latest_period_cost"] == 56.56
+    assert result["total_cost"] == 56.56
+
+
+def test_calculate_gas_cost_skips_meter_replacement_reset() -> None:
+    """A lower read on a new serial (meter replacement) is not billed as negative usage."""
+    schedule = api.parse_gas_rate_schedule(
+        json.dumps(
+            {
+                "conversion_mj_per_unit": 38.6,
+                "seasons": [
+                    {"months": list(range(1, 13)), "tiers": [{"rate": 0.03}]},
+                ],
+            }
+        )
+    )
+    history = [
+        {"date": "2026-08-01", "read_index": 500.0, "serial": "old"},
+        {"date": "2026-08-31", "read_index": 5.0, "serial": "new"},
+        {"date": "2026-09-30", "read_index": 20.0, "serial": "new"},
+    ]
+
+    result = api.calculate_gas_cost(history, schedule)
+
+    # Only the new-meter period (5.0 -> 20.0) should be billed.
+    assert len(result["periods"]) == 1
+    assert result["periods"][0]["mj_used"] == 579.0
+
+
+def test_calculate_gas_cost_returns_empty_without_a_schedule() -> None:
+    """No gas schedule configured means the calculated-cost feature stays disabled."""
+    result = api.calculate_gas_cost(
+        [
+            {"date": "2026-08-01", "read_index": 1.0, "serial": "a"},
+            {"date": "2026-08-31", "read_index": 2.0, "serial": "a"},
+        ],
+        None,
+    )
+    assert result == {"periods": [], "latest_period_cost": None, "total_cost": None}
+
+
+def test_meter_type_description_looks_up_by_serial() -> None:
+    """Meter type descriptions are looked up by serial number, and missing serials are safe."""
+    payload = {"data": {"700594829": "Smart", "080625": "Manually read interval"}}
+
+    assert api.meter_type_description(payload, "700594829") == "Smart"
+    assert api.meter_type_description(payload, "080625") == "Manually read interval"
+    assert api.meter_type_description(payload, "unknown-serial") is None
+    assert api.meter_type_description(payload, None) is None
+    assert api.meter_type_description(None, "700594829") is None
 
 
 def test_cost_summary_exposes_daily_net_totals() -> None:
@@ -833,6 +1225,23 @@ def load_tests(
         test_cost_summary_net_daily_is_sum_not_last_row,
         test_cost_summary_ignores_supply_only_partial_latest_day,
         test_usage_summary_tracks_all_registers_and_b_exports,
+        test_usage_summary_retains_intervals_for_every_day,
+        test_usage_attributes_expose_recent_intervals_by_day_when_requested,
+        test_usage_intervals_are_not_double_counted_across_tou_periods,
+        test_cost_summary_breaks_down_by_charge_type,
+        test_cost_summary_charge_type_totals_empty_when_type_missing,
+        test_meter_type_description_looks_up_by_serial,
+        test_parse_gas_rate_schedule_returns_none_when_blank,
+        test_parse_gas_rate_schedule_requires_positive_conversion_factor,
+        test_calculate_gas_cost_applies_seasonal_tiered_rates_to_average_daily_usage,
+        test_calculate_gas_cost_skips_meter_replacement_reset,
+        test_calculate_gas_cost_returns_empty_without_a_schedule,
+        test_parse_tou_rate_schedule_returns_none_when_blank,
+        test_parse_tou_rate_schedule_parses_windows_and_supply_charge,
+        test_parse_tou_rate_schedule_rejects_malformed_input,
+        test_calculate_tou_cost_splits_usage_by_configured_windows,
+        test_calculate_tou_cost_tracks_unassigned_usage_outside_configured_windows,
+        test_calculate_tou_cost_returns_empty_without_a_schedule,
         test_cost_summary_exposes_new_category_totals,
         test_cost_summary_projects_current_month_cost,
         test_sensor_attributes_are_recorder_safe_summaries,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -45,6 +45,10 @@ class Required:
         return hash((self.key, self.default))
 
 
+class Optional(Required):
+    """Minimal optional field marker."""
+
+
 class ConfigFlow:
     """Minimal stand-in for Home Assistant's config flow base."""
 
@@ -97,10 +101,11 @@ config_entries.ConfigFlow = ConfigFlow
 config_entries.OptionsFlow = OptionsFlow
 data_entry_flow.FlowResult = dict[str, Any]
 voluptuous.Required = Required
+voluptuous.Optional = Optional
 voluptuous.Schema = Schema
 selector.TextSelector = TextSelector
 selector.TextSelectorConfig = lambda **kwargs: kwargs
-selector.TextSelectorType = types.SimpleNamespace(PASSWORD="password")
+selector.TextSelectorType = types.SimpleNamespace(PASSWORD="password", TEXT="text")
 selector.TimeSelector = TimeSelector
 helpers.selector = selector
 homeassistant.config_entries = config_entries
@@ -148,3 +153,69 @@ def test_options_flow_saves_daily_poll_start_time() -> None:
         "title": "",
         "data": {"daily_poll_start_time": "03:00"},
     }
+
+
+def test_options_flow_saves_valid_tou_rate_schedule() -> None:
+    """A well-formed TOU rate schedule is accepted and stored as-is."""
+    flow = config_flow.GloBirdOptionsFlow()
+    schedule_json = (
+        '{"supply_charge": 1.0, "periods": '
+        '[{"name": "Peak", "rate": 0.4, "windows": [["15:00", "21:00"]]}]}'
+    )
+
+    result = asyncio.run(
+        flow.async_step_init(
+            {"daily_poll_start_time": "03:00", "tou_rate_schedule": schedule_json}
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"]["tou_rate_schedule"] == schedule_json
+
+
+def test_options_flow_rejects_invalid_tou_rate_schedule() -> None:
+    """An invalid TOU rate schedule re-shows the form with an error, not a crash."""
+    flow = config_flow.GloBirdOptionsFlow()
+    flow.config_entry = ConfigEntry()
+
+    result = asyncio.run(
+        flow.async_step_init(
+            {"daily_poll_start_time": "03:00", "tou_rate_schedule": "not json"}
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "invalid_tou_rate_schedule"
+
+
+def test_options_flow_saves_valid_gas_rate_schedule() -> None:
+    """A well-formed gas rate schedule is accepted and stored as-is."""
+    flow = config_flow.GloBirdOptionsFlow()
+    schedule_json = (
+        '{"conversion_mj_per_unit": 38.6, "seasons": '
+        '[{"months": [1,2,3,4,5,6,7,8,9,10,11,12], "tiers": [{"rate": 0.03}]}]}'
+    )
+
+    result = asyncio.run(
+        flow.async_step_init(
+            {"daily_poll_start_time": "03:00", "gas_rate_schedule": schedule_json}
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"]["gas_rate_schedule"] == schedule_json
+
+
+def test_options_flow_rejects_invalid_gas_rate_schedule() -> None:
+    """An invalid gas rate schedule re-shows the form with an error, not a crash."""
+    flow = config_flow.GloBirdOptionsFlow()
+    flow.config_entry = ConfigEntry()
+
+    result = asyncio.run(
+        flow.async_step_init(
+            {"daily_poll_start_time": "03:00", "gas_rate_schedule": "not json"}
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "invalid_gas_rate_schedule"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,6 +8,7 @@ import sys
 import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 COMPONENT_PATH = Path(__file__).parents[1] / "custom_components"
@@ -105,6 +106,39 @@ def test_invalid_daily_poll_start_time_falls_back_to_default() -> None:
         now,
         coordinator._parse_daily_poll_start_time("25:99"),
     ) == timedelta(hours=13, minutes=35)
+
+
+def test_daily_poll_start_time_reads_real_ha_mappingproxytype_options() -> None:
+    """Real Home Assistant ConfigEntry.options is a MappingProxyType, not a dict.
+
+    isinstance(options, dict) is False for MappingProxyType, so a check using
+    dict instead of collections.abc.Mapping would silently ignore every
+    configured option on real Home Assistant while appearing to work in
+    tests that use a plain dict.
+    """
+    instance = object.__new__(coordinator.GloBirdCoordinator)
+    instance.entry = types.SimpleNamespace(
+        options=MappingProxyType({coordinator.CONF_DAILY_POLL_START_TIME: "03:00"})
+    )
+
+    assert instance._daily_poll_start_time.isoformat() == "03:00:00"
+
+
+def test_parsed_tou_rate_schedule_reads_real_ha_mappingproxytype_options() -> None:
+    """The TOU rate schedule option must also survive a MappingProxyType options object."""
+    instance = object.__new__(coordinator.GloBirdCoordinator)
+    schedule_json = (
+        '{"periods": [{"name": "Peak", "rate": 0.4, "windows": [["15:00", "21:00"]]}]}'
+    )
+    instance.entry = types.SimpleNamespace(
+        options=MappingProxyType({coordinator.CONF_TOU_RATE_SCHEDULE: schedule_json})
+    )
+
+    schedule, error = instance._parsed_tou_rate_schedule()
+
+    assert error is None
+    assert schedule is not None
+    assert schedule["periods"][0]["name"] == "Peak"
 
 
 def test_update_interval_slows_only_when_daily_data_is_ready(monkeypatch: Any) -> None:
@@ -247,6 +281,9 @@ def test_gas_service_fetches_its_own_meter_and_forces_basic_endpoint() -> None:
                     }
                 ]
             },
+            None,
+            None,
+            None,
             None,
             {},
         )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -141,6 +141,7 @@ update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
 update_coordinator.UpdateFailed = UpdateFailed
 recorder_models.StatisticMeanType = StatisticMeanType
 unit_conversion.VolumeConverter = types.SimpleNamespace(UNIT_CLASS="volume")
+unit_conversion.EnergyConverter = types.SimpleNamespace(UNIT_CLASS="energy")
 dt.now = lambda: datetime.now(timezone.utc)
 util.dt = dt
 util.unit_conversion = unit_conversion
@@ -426,6 +427,291 @@ def test_gas_statistics_ignore_downward_correction_without_double_counting() -> 
     )
 
     assert [row["sum"] for row in statistics] == [100.0, 100.0, 102.0]
+
+
+def test_usage_half_hourly_statistics_aggregate_into_hourly_buckets() -> None:
+    """Sub-hourly intervals are summed into hourly rows with a running sum.
+
+    Home Assistant's recorder rejects external statistics whose `start` is
+    not exactly on the hour, so even though GloBird reports finer-grained
+    intervals (5- or 30-minute), the statistics import must bucket them to
+    the hour before handing them to async_add_external_statistics.
+    """
+    local_tz = timezone(timedelta(hours=10))
+    statistics = sensor._build_usage_half_hourly_statistics(
+        [
+            {"readDate": "2026-04-23", "intervals": [0.1] * 48},
+            {"readDate": "2026-04-24", "intervals": [0.5, 1.5] + [0.0] * 46},
+        ],
+        tzinfo=local_tz,
+    )
+
+    # 24 hourly rows per day, not 48 half-hourly rows.
+    assert len(statistics) == 48
+    assert all(row["start"].minute == 0 and row["start"].second == 0 for row in statistics)
+    assert [row["state"] for row in statistics[:3]] == [0.2, 0.2, 0.2]
+    assert statistics[23]["sum"] == 4.8
+    assert statistics[24]["sum"] == 6.8
+    assert statistics[25]["sum"] == 6.8
+    assert statistics[0]["start"] == datetime(2026, 4, 23, 0, 0, tzinfo=local_tz)
+    assert statistics[1]["start"] == datetime(2026, 4, 23, 1, 0, tzinfo=local_tz)
+    assert statistics[24]["start"] == datetime(2026, 4, 24, 0, 0, tzinfo=local_tz)
+
+
+def test_usage_half_hourly_statistics_skip_days_without_intervals() -> None:
+    """Rows missing a parseable date or interval array are ignored, not errored."""
+    statistics = sensor._build_usage_half_hourly_statistics(
+        [
+            {"readDate": "not-a-date", "intervals": [1.0]},
+            {"readDate": "2026-04-24", "intervals": []},
+            {"readDate": "2026-04-25", "intervals": [1.0, 2.0]},
+        ],
+        tzinfo=timezone.utc,
+    )
+
+    assert len(statistics) == 2
+    assert statistics[0]["start"] == datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
+    assert statistics[0]["sum"] == 1.0
+    assert statistics[1]["start"] == datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert statistics[1]["sum"] == 3.0
+
+
+def test_usage_total_sensor_exposes_recent_intervals_by_day() -> None:
+    """Recent Usage Total attributes include a truncated intervals_by_day window."""
+
+    class FakeCoordinator:
+        data = {
+            "service_data": {
+                "svc-1": {
+                    "usage_summary": {
+                        "total_usage": 10.0,
+                        "intervals_by_day": [
+                            {"readDate": "2026-04-24", "intervals": [1.0, 2.0]}
+                        ],
+                        "daily": [],
+                        "registers": [],
+                    },
+                }
+            }
+        }
+
+    sensor_entity = sensor.GloBirdUsageTotalSensor(
+        FakeCoordinator(),
+        types.SimpleNamespace(entry_id="entry-1"),
+        {"accountServiceId": "svc-1", "siteIdentifier": "svc-1"},
+    )
+
+    attrs = sensor_entity.extra_state_attributes
+    assert attrs["intervals_by_day"] == [
+        {"readDate": "2026-04-24", "intervals": [1.0, 2.0]}
+    ]
+    assert attrs["intervals_by_day_count"] == 1
+    assert attrs["intervals_by_day_truncated"] is False
+
+
+def test_daily_cost_statistics_accumulate_across_days() -> None:
+    """Each day's net cost total becomes a statistic row with a running sum."""
+    local_tz = timezone(timedelta(hours=10))
+    statistics = sensor._build_daily_cost_statistics(
+        [
+            {"date": "2026/09/01", "amount": 2.47},
+            {"date": "2026/09/02", "amount": 2.35},
+            {"date": "2026/09/03", "amount": 2.55},
+        ],
+        tzinfo=local_tz,
+    )
+
+    assert [row["state"] for row in statistics] == [2.47, 2.35, 2.55]
+    assert [row["sum"] for row in statistics] == [2.47, 4.82, 7.37]
+    assert statistics[0]["start"] == datetime(2026, 9, 1, 0, 0, tzinfo=local_tz)
+    assert statistics[2]["start"] == datetime(2026, 9, 3, 0, 0, tzinfo=local_tz)
+
+
+def test_daily_cost_statistics_skip_rows_without_a_parseable_date_or_amount() -> None:
+    """Malformed rows are ignored rather than raising."""
+    statistics = sensor._build_daily_cost_statistics(
+        [
+            {"date": "not-a-date", "amount": 1.0},
+            {"date": "2026/09/01", "amount": None},
+            {"date": "2026/09/02", "amount": 3.0},
+        ],
+        tzinfo=timezone.utc,
+    )
+
+    assert len(statistics) == 1
+    assert statistics[0]["sum"] == 3.0
+
+
+def test_cost_total_sensor_statistic_id_matches_usage_pattern() -> None:
+    """Cost statistics reuse the same recorder-safe id derivation as usage/gas."""
+    suffix = sensor._safe_statistic_id("entry-1_service_svc-1_cost_total", "svc-1")
+    statistic_id = f"{sensor.DOMAIN}:{suffix}"
+    assert statistic_id.startswith(f"{sensor.DOMAIN}:")
+    assert "cost_total" in statistic_id
+
+
+def test_calculated_cost_sensor_unavailable_without_schedule() -> None:
+    """No configured TOU schedule means the sensor is unavailable, not zero."""
+
+    class FakeCoordinator:
+        data = {"service_data": {"svc-1": {"calculated_cost_summary": {}}}}
+
+    sensor_entity = sensor.GloBirdCalculatedCostSensor(
+        FakeCoordinator(),
+        types.SimpleNamespace(entry_id="entry-1"),
+        {"accountServiceId": "svc-1", "siteIdentifier": "svc-1", "serviceType": "Power"},
+    )
+
+    assert sensor_entity.available is False
+    assert sensor_entity.native_value is None
+
+
+def test_calculated_cost_sensor_exposes_latest_day_breakdown() -> None:
+    """With a schedule configured, state/attributes reflect the latest calculated day."""
+
+    class FakeCoordinator:
+        data = {
+            "tou_schedule_error": None,
+            "service_data": {
+                "svc-1": {
+                    "calculated_cost_summary": {
+                        "days": 1,
+                        "latest_day": "2026-09-01",
+                        "latest_day_cost": 3.40,
+                        "total_cost": 3.40,
+                        "daily": [
+                            {
+                                "readDate": "2026-09-01",
+                                "total_cost": 3.40,
+                                "usage_cost": 2.40,
+                                "supply_charge": 1.0,
+                                "unassigned_kwh": 0.0,
+                                "periods": [
+                                    {
+                                        "name": "Offpeak",
+                                        "kwh": 2.0,
+                                        "cost": 0.4,
+                                        "rate": 0.2,
+                                    },
+                                    {
+                                        "name": "Peak",
+                                        "kwh": 4.0,
+                                        "cost": 2.0,
+                                        "rate": 0.5,
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                }
+            },
+        }
+
+    sensor_entity = sensor.GloBirdCalculatedCostSensor(
+        FakeCoordinator(),
+        types.SimpleNamespace(entry_id="entry-1"),
+        {"accountServiceId": "svc-1", "siteIdentifier": "svc-1", "serviceType": "Power"},
+    )
+
+    assert sensor_entity.available is True
+    assert sensor_entity.native_value == 3.40
+    attrs = sensor_entity.extra_state_attributes
+    assert attrs["total_cost"] == 3.40
+    assert attrs["latest_day_unassigned_kwh"] == 0.0
+    assert len(attrs["latest_day_periods"]) == 2
+    assert attrs["schedule_error"] is None
+
+
+def test_calculated_gas_cost_sensor_unavailable_without_schedule() -> None:
+    """No configured gas rate schedule means the sensor is unavailable."""
+
+    class FakeCoordinator:
+        data = {"service_data": {"svc-gas": {"calculated_gas_cost_summary": {}}}}
+
+    sensor_entity = sensor.GloBirdCalculatedGasCostSensor(
+        FakeCoordinator(),
+        types.SimpleNamespace(entry_id="entry-1"),
+        {"accountServiceId": "svc-gas", "siteIdentifier": "svc-gas", "serviceType": "Gas"},
+    )
+
+    assert sensor_entity.available is False
+    assert sensor_entity.native_value is None
+
+
+def test_calculated_gas_cost_sensor_exposes_latest_period_breakdown() -> None:
+    """With a schedule configured, state/attributes reflect the latest billed period."""
+
+    class FakeCoordinator:
+        data = {
+            "gas_schedule_error": None,
+            "service_data": {
+                "svc-gas": {
+                    "calculated_gas_cost_summary": {
+                        "periods": [
+                            {
+                                "start": "2026-08-01",
+                                "end": "2026-08-31",
+                                "days": 30,
+                                "mj_used": 1158.0,
+                                "avg_daily_mj": 38.6,
+                                "season": "Winter",
+                                "usage_cost": 38.95,
+                                "daily_charge_cost": 17.61,
+                                "total_cost": 56.56,
+                            }
+                        ],
+                        "latest_period_cost": 56.56,
+                        "total_cost": 56.56,
+                    }
+                }
+            },
+        }
+
+    sensor_entity = sensor.GloBirdCalculatedGasCostSensor(
+        FakeCoordinator(),
+        types.SimpleNamespace(entry_id="entry-1"),
+        {"accountServiceId": "svc-gas", "siteIdentifier": "svc-gas", "serviceType": "Gas"},
+    )
+
+    assert sensor_entity.available is True
+    assert sensor_entity.native_value == 56.56
+    attrs = sensor_entity.extra_state_attributes
+    assert attrs["total_cost"] == 56.56
+    assert attrs["periods"] == 1
+    assert attrs["schedule_error"] is None
+
+
+def test_meter_info_sensor_exposes_meter_type_description() -> None:
+    """Meter Info attributes surface the looked-up meter type description."""
+
+    class FakeCoordinator:
+        data = {
+            "service_data": {
+                "svc-1": {
+                    "meter": {"meterReadType": "SMART", "serialStatus": "Energized"},
+                    "meter_type_description": "Smart",
+                }
+            }
+        }
+
+    sensor_entity = sensor.GloBirdMeterInfoSensor(
+        FakeCoordinator(),
+        types.SimpleNamespace(entry_id="entry-1"),
+        {"accountServiceId": "svc-1", "siteIdentifier": "svc-1", "serviceType": "Power"},
+    )
+
+    assert sensor_entity.extra_state_attributes["meter_type_description"] == "Smart"
+
+
+def test_weather_impacted_days_sensor_reads_numeric_value() -> None:
+    """Weather Impacted Days surfaces numberOfImpactedDays from the account payload."""
+    description = next(
+        d for d in sensor.GLOBAL_SENSORS if d.key == "weather_impacted_days"
+    )
+
+    data = {"weather_impacted_days": {"data": {"numberOfImpactedDays": 3}}}
+    assert description.value_fn(data) == 3
+    assert description.value_fn({}) is None
 
 
 def test_latest_gas_reading_sensor_exposes_reading_summary() -> None:


### PR DESCRIPTION
## Summary

Found and fixed while validating against a real live account with a time-of-use electricity plan and a pending gas switch.

- **Bug fix**: the portal attaches the same full-day `usageArray` to every time-of-use row (Peak/Offpeak) for a meter register, but the existing code summed that array once per row instead of once per register — silently doubling (or worse) interval totals on any time-of-use account. This affected the existing `latest_intervals` attribute.
- Import smart-meter usage into HA recorder long-term statistics (Recent Usage Total), aggregated to **hourly** resolution — HA's recorder rejects external statistics whose timestamp isn't exactly on the hour, regardless of source interval width (GloBird reports 5- or 30-minute intervals depending on the meter). Finer-grained data is preserved separately via a new `intervals_by_day` attribute.
- Import net daily cost into recorder statistics too (Recent Cost Total), so it can be paired with the usage statistic as the Energy Dashboard's cost source.
- Add manually-configured rate schedules (JSON, integration options) and **Calculated TOU Cost** / **Calculated Gas Cost** sensors, since GloBird's API exposes no usable rate data — verified directly against `getProductsByAccountId` and `getAllProductHistoriesByAccountId` (found via the portal's own JS bundle), both of which return only plan name/dates/flags, never `$/kWh` or `$/MJ` figures. Electricity (time-of-use windows) and gas (seasonal inclining-block tiers on average usage per meter-read period) are billed completely differently, so each gets its own schedule format and calculator.
- Fix a separate, more fundamental bug found while adding the rate schedule option: real Home Assistant's `ConfigEntry.options` is a `types.MappingProxyType`, and `isinstance(options, dict)` evaluates `False` for that type — so the existing `daily_poll_start_time` option (and the new rate schedule options) were being silently ignored on real installs despite passing tests that used plain dicts. Now checks `collections.abc.Mapping`, with a regression test built on an actual `MappingProxyType`.
- Wire up two endpoints that were already being fetched every sync but never surfaced anywhere (`meter_types`, `weather_impacted_days`) into a Weather Impacted Days sensor and a meter type description on Meter Info, and add a cost breakdown by time-of-use charge type for accounts whose plan bills cost per period.

## Test plan

- [x] `pytest tests/` — 81 passing (added/updated tests for every change above)
- [x] Validated the TOU double-count fix, hourly statistics aggregation, and calculated-cost math by hand against real account data (live smart meter interval payloads, real GLOSAVE gas rate card)
- [x] Confirmed via the portal's own JS bundle that no rate/tariff endpoint exists beyond the two product-metadata endpoints checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)